### PR TITLE
fix: Improved UX of sorting with titanium data table header

### DIFF
--- a/packages/storybook/stories/data-table.stories.js
+++ b/packages/storybook/stories/data-table.stories.js
@@ -1,4 +1,4 @@
-import { storiesOf } from '@storybook/polymer/dist/client/preview/index';
+import { storiesOf, forceReRender } from '@storybook/polymer/dist/client/preview/index';
 import { html } from 'lit-html';
 import { withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -21,6 +21,18 @@ const availableCssVars = {
     },
   ],
 };
+
+let sortDirection = 'desc';
+let sortBy = 'Name';
+const onSortDirectionChange = event => {
+  sortDirection = event.detail;
+  forceReRender();
+};
+const onSortByChange = event => {
+  sortBy = event.detail;
+  forceReRender();
+};
+
 //TODO: Make more demos
 storiesOf('UI COMPONENTS|titanium-data-table', module)
   .addDecorator(withKnobs)
@@ -47,8 +59,26 @@ storiesOf('UI COMPONENTS|titanium-data-table', module)
           <titanium-chip label="Hello" closeable slot="table-sub-actions"></titanium-chip>
           <titanium-chip label="World" closeable slot="table-sub-actions"></titanium-chip>
 
-          <titanium-data-table-header slot="table-headers" large columnName="Name" title="Name" sortBy="Name"></titanium-data-table-header>
-          <titanium-data-table-header slot="table-headers" desktop title="Short Name" sortBy="SName"></titanium-data-table-header>
+          <titanium-data-table-header
+            @sort-by-changed=${onSortByChange}
+            .sortBy=${sortBy}
+            .sortDirection=${sortDirection}
+            @sort-direction-changed=${onSortDirectionChange}
+            column-name="Name"
+            slot="table-headers"
+            large
+            title="Name"
+          ></titanium-data-table-header>
+          <titanium-data-table-header
+            @sort-by-changed=${onSortByChange}
+            .sortBy=${sortBy}
+            .sortDirection=${sortDirection}
+            @sort-direction-changed=${onSortDirectionChange}
+            column-name="SName"
+            slot="table-headers"
+            desktop
+            title="Short Name"
+          ></titanium-data-table-header>
           <titanium-data-table-header slot="table-headers" no-sort desktop title="Type"></titanium-data-table-header>
           <titanium-data-table-header slot="table-headers" no-sort desktop center width="105px" title="Phone Number"></titanium-data-table-header>
           <titanium-data-table-header slot="table-headers" no-sort width="75px" right title="Locations"></titanium-data-table-header>
@@ -87,8 +117,26 @@ storiesOf('UI COMPONENTS|titanium-data-table', module)
           <titanium-chip label="Hello" closeable slot="table-sub-actions"></titanium-chip>
           <titanium-chip label="World" closeable slot="table-sub-actions"></titanium-chip>
 
-          <titanium-data-table-header slot="table-headers" large columnName="Name" title="Name" sortBy="Name"></titanium-data-table-header>
-          <titanium-data-table-header slot="table-headers" desktop title="Short Name" sortBy="SName"></titanium-data-table-header>
+          <titanium-data-table-header
+            @sort-by-changed=${onSortByChange}
+            .sortBy=${sortBy}
+            .sortDirection=${sortDirection}
+            @sort-direction-changed=${onSortDirectionChange}
+            column-name="Name"
+            slot="table-headers"
+            large
+            title="Name"
+          ></titanium-data-table-header>
+          <titanium-data-table-header
+            @sort-by-changed=${onSortByChange}
+            .sortBy=${sortBy}
+            .sortDirection=${sortDirection}
+            @sort-direction-changed=${onSortDirectionChange}
+            column-name="SName"
+            slot="table-headers"
+            desktop
+            title="Short Name"
+          ></titanium-data-table-header>
           <titanium-data-table-header slot="table-headers" no-sort desktop title="Type"></titanium-data-table-header>
           <titanium-data-table-header slot="table-headers" no-sort desktop center width="105px" title="Phone Number"></titanium-data-table-header>
           <titanium-data-table-header slot="table-headers" no-sort width="75px" right title="Locations"></titanium-data-table-header>

--- a/packages/titanium-data-table/src/titanium-data-table-header.ts
+++ b/packages/titanium-data-table/src/titanium-data-table-header.ts
@@ -22,11 +22,13 @@ export class TitaniumDataTableHeaderElement extends LitElement {
 
   firstUpdated() {
     this.addEventListener('click', () => {
-      this.sortBy = this.columnName;
-      this.dispatchEvent(new CustomEvent('sort-by-changed', { detail: this.sortBy }));
-
-      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
-      this.dispatchEvent(new CustomEvent('sort-direction-changed', { detail: this.sortDirection }));
+      if (this.active) {
+        this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+        this.dispatchEvent(new CustomEvent('sort-direction-changed', { detail: this.sortDirection }));
+      } else {
+        this.sortBy = this.columnName;
+        this.dispatchEvent(new CustomEvent('sort-by-changed', { detail: this.sortBy }));
+      }
     });
   }
 


### PR DESCRIPTION
The purpose of this PR is to make it so that when one switches between active table headers the sort direction does not change.  When the user changes the sort direction by clicking on an active table header it stays that way again between switches between headers.