### PR TITLE
fix: Supresses intial page-chage event (0) on DT load

### DIFF
--- a/packages/titanium-data-table/src/titanium-data-table.ts
+++ b/packages/titanium-data-table/src/titanium-data-table.ts
@@ -24,7 +24,6 @@ export class TitaniumDataTableElement extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.setTake(this._determineTake());
-    this.setPage(0);
     this.addEventListener('titanium-data-table-item-selected-changed', this._handleItemSelectionChange.bind(this));
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Data Table no longer emits an initial page change event when it is connected.
