### PR TITLE
Loading scroll issue

### DIFF
--- a/packages/titanium-loading-indicator/src/titanium-full-page-loading-indicator.ts
+++ b/packages/titanium-loading-indicator/src/titanium-full-page-loading-indicator.ts
@@ -27,9 +27,8 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
       this._openCount++;
       try {
         await e.detail.promise;
-      }
-      catch { }
-      finally {
+      } catch {
+      } finally {
         this._openCount--;
         if (this._openCount === 0) {
           this._close();
@@ -46,11 +45,7 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
       this.opened = false;
       this.opening = true;
 
-      if (window.innerWidth > document.documentElement.clientWidth) {
-        document.body.style.overflowY = 'scroll';
-        document.body.style.position = 'fixed';
-        document.body.style.width = '100%';
-      }
+      document.body.style.overflow = 'hidden';
 
       this.runNextAnimationFrame_(() => {
         this.opened = true;
@@ -76,9 +71,7 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
       clearTimeout(this._animationTimer);
       this._animationTimer = window.setTimeout(() => {
         this.handleAnimationTimerEnd_();
-        document.body.style.overflowY = '';
-        document.body.style.position = '';
-        document.body.style.width = '';
+        document.body.style.overflow = '';
       }, 150);
     }, closeDelay);
   }


### PR DESCRIPTION
This change solves the issue of pages being scrolled to the top whenever a modal is opened for the first time.

Currently the way that full-page-loading-indicator is setting styles, on open and close, is causing modals to scroll the body of a page to the top. Some pages are very short, so it's not a huge issue on those, but others scroll quite a bit (The hire form on employee manager being the main example here).

I noticed that these styles were added in to fix a scroll issue about a month ago, but after effectively reverting those changes, I can't find what the scrolling issue was previously. 

The scrolling only happens when an api call is made, but the styling here seems to be affecting it as well. I haven't been able to track down an api-service or network related issue that's causing it, so this is what I have to solve this issue as of now. I'm open to a different approach if needed of course