### PR TITLE
fix(titanium-single-select): Updates logic for hint and result text

### DIFF
--- a/packages/titanium-single-select/src/titanium-single-select.ts
+++ b/packages/titanium-single-select/src/titanium-single-select.ts
@@ -524,8 +524,9 @@ export class TitaniumSingleSelectElement<T> extends LitElement {
         <titanium-progress ?hidden=${!this._isLoading || !this.open} ?disabled=${!this._isLoading}></titanium-progress>
       </input-container>
       <search-suggestions id="suggestions" tabindex="-1">
-        <informatory-text ?hidden=${this.totalCount > 0 || this.inputValue !== ''}>${this.hintText}</informatory-text>
-        <informatory-text ?hidden=${this.inputValue === '' || this._isLoading}> ${this.totalCount} results for '${this.inputValue}' </informatory-text>
+        <informatory-text ?hidden=${this._isLoading}
+          >${this.inputValue === '' ? this.hintText : this.totalCount + ' results for ' + this.inputValue}</informatory-text
+        >
         <slot></slot>
       </search-suggestions>
     `;


### PR DESCRIPTION
Currently titanium-single-select will not show the hint text after a search is attempted and then cleared. A result box shows with nothing in it.

This makes it so that the hint text will show up when there is no search term, even after an initial search is attempted and cleared. It retains switching between the hint text and the informatory text letting the user know how many results there are.