### PR TITLE
fix: look for id to use as localStorage identifier instead of header

### DIFF
--- a/packages/titanium-data-table/src/titanium-data-table.ts
+++ b/packages/titanium-data-table/src/titanium-data-table.ts
@@ -202,7 +202,8 @@ export class TitaniumDataTableElement extends LitElement {
   }
 
   private _determineTake() {
-    const take = Number(window.localStorage.getItem(`${this.header}-take`)) || 0;
+    const id = this.getAttribute("id");
+    const take = Number(window.localStorage.getItem(`${ id ?? this.header}-take`)) || 0;
     if (take > 0) {
       return take;
     }

--- a/packages/titanium-data-table/src/titanium-data-table.ts
+++ b/packages/titanium-data-table/src/titanium-data-table.ts
@@ -202,7 +202,7 @@ export class TitaniumDataTableElement extends LitElement {
   }
 
   private _determineTake() {
-    const id = this.getAttribute("id");
+    const id = this.getAttribute('id');
     const take = Number(window.localStorage.getItem(`${ id ?? this.header}-take`)) || 0;
     if (take > 0) {
       return take;


### PR DESCRIPTION
Required to maintain take if header is not static.