### PR TITLE
Abort controller idea

### DIFF
--- a/packages/api-service/src/api-service.ts
+++ b/packages/api-service/src/api-service.ts
@@ -291,7 +291,7 @@ export default class ApiService {
     }
   }
 
-  async getAsync<T>(urlPath: string, appName: string | null = null): Promise<ODataResponse<T>> {
+  async getAsync<T>(urlPath: string, appName: string | null = null, controller: AbortController | null = null): Promise<ODataResponse<T>> {
     const headers = { ...this.headers };
     if (appName !== null) {
       headers['X-LGAppName'] = appName;
@@ -306,6 +306,7 @@ export default class ApiService {
       response = await fetch(`${this.baseUrl}${urlPath}`, {
         method: 'GET',
         headers: headers,
+        signal: controller?.signal ?? undefined
       });
     } catch (error) {
       if (error.message != null && error.message.indexOf('Failed to fetch') !== -1) {

--- a/packages/storybook/stories/api-service.stories.mdx
+++ b/packages/storybook/stories/api-service.stories.mdx
@@ -1,0 +1,63 @@
+import { Story, Preview, Meta, Props } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
+import { html } from 'lit-html';
+import { withKnobs, boolean, text, number } from '@storybook/addon-knobs';
+import { withWebComponentsKnobs } from '../index.js';
+
+import '@leavittsoftware/leavitt-elements/lib/leavitt-person-select';
+import '@leavittsoftware/user-manager';
+
+<Meta
+  title="Communication|Api Service"
+  decorators={[withKnobs, withWebComponentsKnobs]}
+  parameters={{ component: 'api-service', options: { selectedPanel: 'storybookjs/knobs/panel' } }}
+/>
+
+# Api Service
+
+Communicate with Leavitt APIs.
+
+## How to use
+
+```bash
+npm i @leavittsoftware/api-service
+```
+
+```js
+import Api2ServiceMixin from '@leavittsoftware/api-service/lib/api2-service';
+...
+export class DemoElement extends Api2ServiceMixin(LoadWhile(LitElement)) {
+    @property({ type: Array }) abortControllers: Array<AbortController> = [];
+    @property({ type: Array }) fruits: Array<Fruit> = [];
+
+    private async get() {
+        // Cancel any pending requests
+        this.abortControllers.map(c => c.abort());
+        this.abortControllers = [];
+        try {
+            const controller = new AbortController();
+            const get = this.api2.getAsync<Fruit>('Fruits/?$top=5&$orderby=Id desc', 'Testing', controller);
+            this.abortControllers.push(controller);
+            this.dispatchEvent(new PendingStateEvent(get));
+            this.loadWhile(get);
+            const result = await get;
+            this.fruits = result.toList();
+        } catch (error) {
+            if (error.name != 'AbortError') {
+                this.errorMessage = error;
+                AppSnackbar.open(error);
+            }
+        }
+    }
+}
+```
+
+## API
+
+<Props of="api-service" />
+
+## Demo
+
+<Preview withToolbar>
+  <Story name="Docs">{html`<api-service appName="Testing"></api-service>`}</Story>
+</Preview>


### PR DESCRIPTION
Just an idea on how we can handle multiple large requests (would need to be fleshed out). The current issue is promise based loaders (like the veil) may be be waiting on large responses that are no longer needed such as in a search. I think we need a way to `abort` requests as needed.

Here's an idea on how we might be able to use it
```
    this.abortControllers.map(c => c.abort());
    this.abortControllers = [];

    const controller = new AbortController();
    const get = this.api2.getAsync<Partial<Person>>(`People/?${odataParts.join('&')}`, 'Snapshot', controller);
    this.abortControllers.push(controller);
```