### PR TITLE
Fix titanium-address-input going into error state when it's not supposed to.

### DIFF
--- a/packages/titanium-address-input/src/google-address-input.ts
+++ b/packages/titanium-address-input/src/google-address-input.ts
@@ -92,7 +92,7 @@ export class GoogleAddressInput extends LitElement {
 
   private async _setUpAutocomplete() {
     await this.input.updateComplete;
-    this.autocomplete = new google.maps.places.Autocomplete(this.input.formElement, { types: ['address'] });
+    this.autocomplete = new google.maps.places.Autocomplete(this.input.formElement, { fields: ['address_components', 'formatted_address'], types: ['address'] });
     google.maps.event.addListener(this.autocomplete, 'place_changed', this._onPlaceChanged.bind(this));
   }
 

--- a/packages/titanium-address-input/src/google-address-input.ts
+++ b/packages/titanium-address-input/src/google-address-input.ts
@@ -98,7 +98,7 @@ export class GoogleAddressInput extends LitElement {
 
   private async _setUpAutocomplete() {
     await this.input.updateComplete;
-    this.autocomplete = new google.maps.places.Autocomplete(this.input.formElement, { fields: ['address_components', 'formatted_address'], types: ['address'] });
+    this.autocomplete = new google.maps.places.Autocomplete(this.input.formElement, { fields: ['address_components', 'formatted_address', 'geometry'], types: ['address'] });
     google.maps.event.addListener(this.autocomplete, 'place_changed', this._onPlaceChanged.bind(this));
   }
 

--- a/packages/titanium-address-input/src/google-address-input.ts
+++ b/packages/titanium-address-input/src/google-address-input.ts
@@ -13,7 +13,7 @@ export class GoogleAddressInput extends LitElement {
   @property({ type: Boolean }) outlined: boolean;
   @property({ type: String }) validationMessage: string;
   @property({ type: String }) icon: string;
-  @property({ type: Object }) location: Partial<Address> | null;
+  @property({ type: Object }) location: Partial<Address> | null = null;
   @property({ type: String }) label: string = 'Address';
   @property({ type: String }) googleMapsApiKey: string;
   @property({ type: String }) helper: string;
@@ -29,6 +29,9 @@ export class GoogleAddressInput extends LitElement {
 
   async updated(changedProps: Map<keyof this, unknown>) {
     if (changedProps.has('location')) {
+      if (typeof changedProps.get('location') === 'undefined') {
+        return;
+      }
       this.inputValue = addressToString(this.location);
 
       await this.input.updateComplete;

--- a/packages/titanium-address-input/src/google-address-input.ts
+++ b/packages/titanium-address-input/src/google-address-input.ts
@@ -38,7 +38,10 @@ export class GoogleAddressInput extends LitElement {
 
   async firstUpdated() {
     this.input.validityTransform = () => {
-      if (!this.location || !validateStreet(this.location?.street ?? '') || !this.location.city || !this.location.state || !this.location.zip) {
+      if (
+           (this.location && (!validateStreet(this.location?.street ?? '') || !this.location.city || !this.location.state || !this.location.zip))
+        || (this.required && !this.location)
+      ) {
         return {
           valid: false,
         };

--- a/packages/titanium-address-input/src/titanium-address-input.ts
+++ b/packages/titanium-address-input/src/titanium-address-input.ts
@@ -12,7 +12,7 @@ export class TitaniumAddressInput extends LitElement {
   @property({ type: Boolean }) required: boolean;
   @property({ type: Boolean }) outlined: boolean;
   @property({ type: String }) validationMessage: string;
-  @property({ type: Object }) location: Partial<Address> | null;
+  @property({ type: Object }) location: Partial<Address> | null = null;
   @property({ type: String }) label: string = 'Address';
   @property({ type: String }) icon: string;
   @property({ type: String }) googleMapsApiKey: string;


### PR DESCRIPTION
Fixes:
- Focusing and exiting a non-required field causes error state.
- Field enters invalid state on first .reset() after loading.
- Request to google API was requesting all data fields back costing extra money and bandwidth.