### PR TITLE
Remove cropper image on close dialog

### DIFF
--- a/packages/titanium-image-input/src/image-cropper-dialog.ts
+++ b/packages/titanium-image-input/src/image-cropper-dialog.ts
@@ -144,6 +144,10 @@ export class ImageCropperDialogElement extends LitElement {
         }
       }
 
+      [closing] img {
+        display: none;
+      }
+
       [hidden] {
         display: none !important;
       }
@@ -167,7 +171,7 @@ export class ImageCropperDialogElement extends LitElement {
     this.cropper = new Cropper(this.img, {
       viewMode: 2,
       ...this.options,
-      aspectRatio: this.options.shape === 'circle' ? 1 : this.options.aspectRatio
+      aspectRatio: this.options.shape === 'circle' ? 1 : this.options.aspectRatio,
     });
   }
 
@@ -252,8 +256,8 @@ export class ImageCropperDialogElement extends LitElement {
               }
               this.previewDataUrl = this.options.shape === 'circle' ? await this.applyCircleMask(canvas.toDataURL()) : canvas.toDataURL();
               const response = await fetch(this.previewDataUrl);
-              const blob = await response.blob()
-              this.blobToFile(blob, this.fileName)
+              const blob = await response.blob();
+              this.blobToFile(blob, this.fileName);
               this.file = blob as File;
               this.dialog.close('cropped');
             }}

--- a/packages/titanium-image-input/src/image-cropper-dialog.ts
+++ b/packages/titanium-image-input/src/image-cropper-dialog.ts
@@ -144,10 +144,6 @@ export class ImageCropperDialogElement extends LitElement {
         }
       }
 
-      [closing] img {
-        display: none;
-      }
-
       [hidden] {
         display: none !important;
       }
@@ -162,6 +158,7 @@ export class ImageCropperDialogElement extends LitElement {
   }
 
   reset() {
+    this.img.src = '';
     this.cropper?.destroy();
   }
 


### PR DESCRIPTION
- Image input was leaving a ghost image when uploading and then canceling in the cropper dialog.
- Uploading a large image would show the previously loaded image while uploading the new one. 

![cropper](https://user-images.githubusercontent.com/18709288/133304687-de5cfb00-21f2-4634-a6c3-28bf74d0ed5d.gif)
You can see the bug by going here:
https://devservicetimeline.leavitt.com/admin/cover-pages/add
https://devstationery.leavitt.com/business-cards/111/company/20248
