### PR TITLE
Remove line-height from titanium-side-menu-item so align-items: center can do its thing properly

### DIFF
--- a/packages/titanium-side-menu/src/titanium-side-menu-item.ts
+++ b/packages/titanium-side-menu/src/titanium-side-menu-item.ts
@@ -43,7 +43,6 @@ export class TitaniumSideMenuItemElement extends LitElement {
       align-items: center;
       font-family: Metropolis, Roboto, Noto, sans-serif;
       -webkit-font-smoothing: antialiased;
-      line-height: 24px;
       letter-spacing: 0.35px;
       padding: 10px 16px 10px 24px;
       border-radius: 0 50px 50px 0;


### PR DESCRIPTION
Before | After
:------:|:-----:
![menu-item-before](https://user-images.githubusercontent.com/590826/133862428-d6bb8a97-aad1-4577-af7f-10971baa49ae.png)|![menu-item-after](https://user-images.githubusercontent.com/590826/133862437-7392129f-d600-494a-9d6e-55609408dc50.png)}
