### PR TITLE
fix(titanium-loading-indicator): ensure veil is closed when closing is done

### DIFF
--- a/packages/titanium-loading-indicator/src/titanium-full-page-loading-indicator.ts
+++ b/packages/titanium-loading-indicator/src/titanium-full-page-loading-indicator.ts
@@ -55,6 +55,9 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
       document.body.style.overflow = 'hidden';
 
       this.runNextAnimationFrame_(() => {
+        if (this.closing) {
+          return;
+        }
         this.opened = true;
         this._animationTimer = window.setTimeout(() => {
           this.handleAnimationTimerEnd_();
@@ -79,7 +82,6 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
       this._animationTimer = window.setTimeout(() => {
         this.handleAnimationTimerEnd_();
         document.body.style.overflow = '';
-        this.opened = false;
       }, 150);
     }, closeDelay);
   }

--- a/packages/titanium-loading-indicator/src/titanium-full-page-loading-indicator.ts
+++ b/packages/titanium-loading-indicator/src/titanium-full-page-loading-indicator.ts
@@ -66,7 +66,7 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
   private _close() {
     window.clearTimeout(this._openDelayTimer);
     const totalTimeOpened = performance.now() - this._timeOpen;
-    const closeDelay = totalTimeOpened > this._minTimeOpen ? 0 : this._minTimeOpen - totalTimeOpened || 0;
+    const closeDelay = Math.max(this._minTimeOpen - totalTimeOpened, 0);
 
     this._closeDelayTimer = window.setTimeout(() => {
       cancelAnimationFrame(this._animationFrame);
@@ -79,6 +79,7 @@ export class TitaniumFullPageLoadingIndicatorElement extends LitElement {
       this._animationTimer = window.setTimeout(() => {
         this.handleAnimationTimerEnd_();
         document.body.style.overflow = '';
+        this.opened = false;
       }, 150);
     }, closeDelay);
   }


### PR DESCRIPTION
Should fix issue where sometimes pages fully load but the veil doesn't go away.
https://devpcms.leavitt.com/sales-expectation/10934/expectations seems to trigger the issue often