### PR TITLE
feat(leavitt-elements): expose fixedMenuPosition in elements with menu

### DIFF
--- a/packages/leavitt-elements/src/leavitt-company-select.ts
+++ b/packages/leavitt-elements/src/leavitt-company-select.ts
@@ -52,7 +52,7 @@ export class LeavittCompanyElement extends LoadWhile(LitElement) {
   /**
    *  Sets the dropdown menu's position to fixed. This is useful when the select is inside of a stacking context e.g. inside of an mwc-dialog. Note, that --mdc-menu-min-width or --mdc-menu-max-width may have to be set to resize the menu to the width anchor.
    */
-  @property({ type: Boolean }) fixedMenuPosition: boolean = true;
+  @property({ type: Boolean }) fixedMenuPosition = false;
 
   /**
    *  Disables automatic loading of companies on firstUpdated

--- a/packages/leavitt-elements/src/leavitt-person-company-select.ts
+++ b/packages/leavitt-elements/src/leavitt-person-company-select.ts
@@ -103,6 +103,11 @@ export class LeavittPersonCompanySelectElement extends LoadWhile(LitElement) {
     return {};
   };
 
+  /**
+   *  Sets the dropdown menu's position to fixed. This is useful when the select is inside of a stacking context e.g. inside of an mwc-dialog. Note, that --mdc-menu-min-width or --mdc-menu-max-width may have to be set to resize the menu to the width anchor.
+   */
+  @property({ type: Boolean }) fixedMenuPosition = false;
+
   firstUpdated() {
     this.menu.anchor = this.textfield;
     this.textfield.layout();
@@ -367,7 +372,7 @@ export class LeavittPersonCompanySelectElement extends LoadWhile(LitElement) {
           : ''}
       </div>
       <mwc-menu
-        fixed
+        ?fixed=${this.fixedMenuPosition}
         activatable
         corner="BOTTOM_LEFT"
         defaultFocus="NONE"

--- a/packages/leavitt-elements/src/leavitt-person-group-select.ts
+++ b/packages/leavitt-elements/src/leavitt-person-group-select.ts
@@ -104,6 +104,11 @@ export class LeavittPersonGroupSelectElement extends LoadWhile(LitElement) {
     return {};
   };
 
+  /**
+   *  Sets the dropdown menu's position to fixed. This is useful when the select is inside of a stacking context e.g. inside of an mwc-dialog. Note, that --mdc-menu-min-width or --mdc-menu-max-width may have to be set to resize the menu to the width anchor.
+   */
+  @property({ type: Boolean }) fixedMenuPosition = false;
+
   firstUpdated() {
     this.menu.anchor = this.textfield;
     this.textfield.layout();
@@ -363,7 +368,7 @@ export class LeavittPersonGroupSelectElement extends LoadWhile(LitElement) {
           >`
         : ''}
       <mwc-menu
-        fixed
+        ?fixed=${this.fixedMenuPosition}
         activatable
         corner="BOTTOM_LEFT"
         defaultFocus="NONE"

--- a/packages/leavitt-elements/src/leavitt-person-select.ts
+++ b/packages/leavitt-elements/src/leavitt-person-select.ts
@@ -110,6 +110,11 @@ export class LeavittPersonSelectElement extends LoadWhile(LitElement) {
     return {};
   };
 
+  /**
+   *  Sets the dropdown menu's position to fixed. This is useful when the select is inside of a stacking context e.g. inside of an mwc-dialog. Note, that --mdc-menu-min-width or --mdc-menu-max-width may have to be set to resize the menu to the width anchor.
+   */
+  @property({ type: Boolean }) fixedMenuPosition = false;
+
   firstUpdated() {
     this.menu.anchor = this.textfield;
     this.textfield.layout();
@@ -316,7 +321,7 @@ export class LeavittPersonSelectElement extends LoadWhile(LitElement) {
       ></mwc-textfield>
       ${this.selected ? html` <profile-picture selected .personId=${this.selected?.Id || 0} shape="circle" size="24"></profile-picture>` : ''}
       <mwc-menu
-        fixed
+        ?fixed=${this.fixedMenuPosition}
         activatable
         corner="BOTTOM_LEFT"
         defaultFocus="NONE"


### PR DESCRIPTION
BREAKING CHANGE: defaults position to relative vs fixed.  Use fixedMenuPosition if fixed is desired. 

closes #389
