### PR TITLE
407 Date picker in the filters is allowing an input of six digits for the year.

### DIFF
--- a/packages/leavitt-elements/src/mwc-datefield.ts
+++ b/packages/leavitt-elements/src/mwc-datefield.ts
@@ -50,6 +50,10 @@ export class DateField extends TextField {
      *  @ignore
      */
     this.outlined = true;
+    /**
+     *  @ignore
+     */
+    this.max = '2999-12-31';
   }
 
   static get styles() {


### PR DESCRIPTION
closes #407
