### PR TITLE
411 Create a titanium-duration-input component (take it from logs.leavitt.com)

### DIFF
--- a/packages/leavittbook/package.json
+++ b/packages/leavittbook/package.json
@@ -43,6 +43,7 @@
     "@leavittsoftware/titanium-toolbar": "^0.2.5",
     "@leavittsoftware/titanium-twoline-formfield": "^0.1.3",
     "@leavittsoftware/titanium-youtube-input": "^0.2.3",
+    "@leavittsoftware/titanium-duration-input": "^1.0.0",
     "@leavittsoftware/user-manager": "^9.8.9",
     "@material/mwc-button": "*",
     "@material/mwc-checkbox": "*",

--- a/packages/leavittbook/src/demos/titanium-duration-input/index.html
+++ b/packages/leavittbook/src/demos/titanium-duration-input/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<head>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Material+Icons+Outlined&display=block" rel="stylesheet" />
+  <style>
+    body {
+      font-family: Roboto, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+      background-color: #fff;
+      color: #5f6368;
+
+      --app-primary-color: var(--app-link-color);
+      --app-secondary-color: #4285f4;
+      --app-text-color: #5f6368;
+      --app-light-text-color: #707175;
+      --app-dark-text-color: #202124;
+      --app-hover-color: #f9f9f9;
+      --app-border-color: #dadce0;
+      --app-menu-text-color: #5f6368;
+      --app-link-color: #1a73e8;
+      --material-primary-color: var(--app-secondary-color);
+      --material-primary-text-color: var(--app-link-color);
+      --material-error-text-color: #da3227;
+      --mdc-theme-primary: var(--app-primary-color);
+      --mdc-theme-secondary: var(--app-secondary-color);
+      --mdc-text-field-outlined-idle-border-color: var(--app-border-color);
+      --mdc-select-outlined-idle-border-color: var(--app-border-color);
+      --mdc-icon-font: 'Material Icons Outlined';
+    }
+
+    @font-face {
+      font-family: 'Metropolis';
+      font-weight: 600;
+      font-display: swap;
+      src: local('Metropolis'), url('https://www.leavitt.com/fonts/metropolis-bold.otf') format('opentype');
+    }
+
+    @font-face {
+      font-family: 'Metropolis';
+      font-weight: 500;
+      font-display: swap;
+      src: local('Metropolis'), url('https://www.leavitt.com/fonts/metropolis-semibold.otf') format('opentype');
+    }
+
+    @font-face {
+      font-family: 'Metropolis';
+      font-weight: 400;
+      font-display: swap;
+      src: local('Metropolis'), url('https://www.leavitt.com/fonts/metropolis-medium.otf') format('opentype');
+    }
+  </style>
+
+  <script type="module" src="./titanium-duration-input-playground.js"></script>
+</head>
+<body>
+  <titanium-duration-input-playground></titanium-duration-input-playground>
+</body>

--- a/packages/leavittbook/src/demos/titanium-duration-input/project.json
+++ b/packages/leavittbook/src/demos/titanium-duration-input/project.json
@@ -1,0 +1,8 @@
+{
+  "section": "Basics",
+  "files": {
+    "titanium-duration-input-playground.ts": {},
+    "index.html": {}
+  },
+  "order": 0
+}

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-demo.ts
@@ -1,0 +1,24 @@
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import StoryStyles from '../../styles/story-styles';
+import '../../shared/story-header';
+import '../../shared/smart-demo';
+import './titanium-duration-input-playground';
+
+import '@api-viewer/docs';
+
+@customElement('titanium-duration-input-demo')
+export class TitaniumDurationInputDemoElement extends LitElement {
+  static styles = [StoryStyles, css``];
+
+  render() {
+    return html`
+      <story-header name="Titanium Duration Input" packageName="titanium-duration-input" className="TitaniumDurationInputElement"></story-header>
+      <smart-demo line-numbers resizable project-src="../src/demos/titanium-duration-input/project.json"
+        ><titanium-duration-input-playground></titanium-duration-input-playground>
+      </smart-demo>
+      <api-docs src="./custom-elements.json" selected="titanium-duration-input"></api-docs>
+    `;
+  }
+}

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -68,7 +68,6 @@ export class TitaniumDurationInputPlayground extends LitElement {
       <h1>Required</h1>
       <div>
         <titanium-duration-input required validationMessage="This duration is required" label="Duration" helperPersistent outlined></titanium-duration-input>
-        <p>Duration is: ${this.duration ? html`${this.duration.asSeconds()} seconds` : String(this.duration)}</p>
       </div>
     `;
   }

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -52,7 +52,6 @@ export class TitaniumDurationInputPlayground extends LitElement {
           .duration=${this.duration}
           outlined
           @duration-changed=${event => {
-            console.log(event.target.duration);
             this.duration = event.target.duration;
           }}
         ></titanium-duration-input>

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -1,0 +1,66 @@
+/* playground-fold */
+import { css, html, LitElement } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+import { h1, p, button } from '@leavittsoftware/titanium-styles';
+import '@leavittsoftware/profile-picture';
+import '@material/mwc-button';
+import { TitaniumDurationInputElement } from '@leavittsoftware/titanium-duration-input';
+
+/* playground-fold-end */
+import '@leavittsoftware/titanium-duration-input';
+
+/* playground-fold */
+@customElement('titanium-duration-input-playground')
+export class TitaniumDurationInputPlayground extends LitElement {
+  @query('titanium-duration-input[required]') requiredInput: TitaniumDurationInputElement;
+  @state() duration: number = 1500000000;
+
+  static styles = [
+    h1,
+    p,
+    button,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        --mdc-icon-font: 'Material Icons Outlined';
+        margin: 24px 12px;
+      }
+
+      div {
+        border: 1px solid var(--app-border-color);
+        padding: 24px;
+        border-radius: 8px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin: 24px 0 36px 0;
+      }
+
+      section[buttons] {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+    `,
+  ];
+
+  render() {
+    /* playground-fold-end */
+    return html`
+      <h1>Default</h1>
+      <div>
+        <titanium-duration-input
+          label="Duration"
+          .value=${this.duration}
+          @changed=${event => {
+            this.duration = event.target.value;
+          }}
+        ></titanium-duration-input>
+        <p>${this.duration}</p>
+        <titanium-duration-input label="Duration"></titanium-duration-input>
+      </div>
+    `;
+  }
+}

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -1,19 +1,20 @@
 /* playground-fold */
 import { css, html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import { h1, p, button } from '@leavittsoftware/titanium-styles';
 import '@leavittsoftware/profile-picture';
 import '@material/mwc-button';
-import { TitaniumDurationInputElement } from '@leavittsoftware/titanium-duration-input';
 
 /* playground-fold-end */
 import '@leavittsoftware/titanium-duration-input';
+import dayjs from 'dayjs/esm';
+import duration from 'dayjs/esm/plugin/duration';
+dayjs.extend(duration);
 
 /* playground-fold */
 @customElement('titanium-duration-input-playground')
 export class TitaniumDurationInputPlayground extends LitElement {
-  @query('titanium-duration-input[required]') requiredInput: TitaniumDurationInputElement;
-  @state() duration: number = 1500000000;
+  @state() duration: duration.Duration = dayjs.duration(144000);
 
   static styles = [
     h1,
@@ -31,17 +32,11 @@ export class TitaniumDurationInputPlayground extends LitElement {
         border: 1px solid var(--app-border-color);
         padding: 24px;
         border-radius: 8px;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
         margin: 24px 0 36px 0;
       }
 
-      section[buttons] {
-        display: flex;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: 12px;
+      p {
+        margin-top: 24px;
       }
     `,
   ];
@@ -53,13 +48,15 @@ export class TitaniumDurationInputPlayground extends LitElement {
       <div>
         <titanium-duration-input
           label="Duration"
-          .value=${this.duration}
-          @changed=${event => {
-            this.duration = event.target.value;
+          helperPersistent
+          .duration=${this.duration}
+          outlined
+          @duration-changed=${event => {
+            console.log(event.target.duration);
+            this.duration = event.target.duration;
           }}
         ></titanium-duration-input>
-        <p>${this.duration}</p>
-        <titanium-duration-input label="Duration"></titanium-duration-input>
+        <p>Duration is: ${this.duration ? html`${this.duration.asSeconds()} seconds` : String(this.duration)}</p>
       </div>
     `;
   }

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -14,7 +14,14 @@ dayjs.extend(duration);
 /* playground-fold */
 @customElement('titanium-duration-input-playground')
 export class TitaniumDurationInputPlayground extends LitElement {
-  @state() duration: duration.Duration = dayjs.duration(144000);
+  @state() duration: duration.Duration = dayjs.duration(14400);
+
+  async firstUpdated() {
+    await this.updateComplete;
+    setTimeout(() => {
+      this.duration = dayjs.duration(244000);
+    }, 2000);
+  }
 
   static styles = [
     h1,
@@ -51,7 +58,7 @@ export class TitaniumDurationInputPlayground extends LitElement {
           helperPersistent
           .duration=${this.duration}
           outlined
-          @duration-changed=${event => {
+          @duration-change=${event => {
             this.duration = event.target.duration;
           }}
         ></titanium-duration-input>

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -64,6 +64,12 @@ export class TitaniumDurationInputPlayground extends LitElement {
         ></titanium-duration-input>
         <p>Duration is: ${this.duration ? html`${this.duration.asSeconds()} seconds` : String(this.duration)}</p>
       </div>
+
+      <h1>Required</h1>
+      <div>
+        <titanium-duration-input required validationMessage="This duration is required" label="Duration" helperPersistent outlined></titanium-duration-input>
+        <p>Duration is: ${this.duration ? html`${this.duration.asSeconds()} seconds` : String(this.duration)}</p>
+      </div>
     `;
   }
 }

--- a/packages/leavittbook/src/my-app.ts
+++ b/packages/leavittbook/src/my-app.ts
@@ -180,6 +180,9 @@ export class MyAppElement extends LitElement {
     );
     page('/titanium-color-input', () => this.#changePage('titanium-color-input', () => import('./demos/titanium-color-input/titanium-color-input-demo.js')));
     page('/titanium-show-hide', () => this.#changePage('titanium-show-hide', () => import('./demos/titanium-show-hide/titanium-show-hide-demo.js')));
+    page('/titanium-duration-input', () =>
+      this.#changePage('titanium-duration-input', () => import('./demos/titanium-duration-input/titanium-duration-input-demo.js'))
+    );
 
     page('*', () => {
       this.#changePage('error');
@@ -546,6 +549,10 @@ export class MyAppElement extends LitElement {
                 <mwc-icon><span class="material-icons-outlined"> library_books </span></mwc-icon>
                 <span>titanium-show-hide</span>
               </a>
+              <a href="/titanium-duration-input" ?selected=${!!this.page?.includes('titanium-duration-input')}>
+                <mwc-icon><span class="material-icons-outlined"> library_books </span></mwc-icon>
+                <span>titanium-duration-input</span>
+              </a>
             </details>
           </section>
 
@@ -767,6 +774,9 @@ export class MyAppElement extends LitElement {
             : nothing}
           ${this.page === 'titanium-show-hide'
             ? html` <titanium-show-hide-demo ?isActive=${this.page === 'titanium-show-hide'}></titanium-show-hide-demo> `
+            : nothing}
+          ${this.page === 'titanium-duration-input'
+            ? html` <titanium-duration-input-demo ?isActive=${this.page === 'titanium-duration-input'}></titanium-duration-input-demo> `
             : nothing}
         </div>
       </mwc-drawer>

--- a/packages/titanium-duration-input/.gitignore
+++ b/packages/titanium-duration-input/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+lib/**/*

--- a/packages/titanium-duration-input/package.json
+++ b/packages/titanium-duration-input/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@leavittsoftware/titanium-duration-input",
+  "description": "",
+  "author": "Leavitt Software",
+  "version": "1.0.0",
+  "license": "MIT",
+  "main": "lib/titanium-duration-input.js",
+  "typings": "lib/titanium-duration-input.d.ts",
+  "homepage": "https://github.com/LeavittSoftware/titanium-elements/tree/master/packages/titanium-duration-input",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "keywords": [
+    "web component"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeavittSoftware/titanium-elements.git"
+  },
+  "dependencies": {
+    "@material/mwc-textfield": "*",
+    "luxon": "3.0.3",
+    "tslib": "^2.4.0"
+  },
+  "peerDependencies": {
+    "lit": ">=2.3.0"
+  },
+  "scripts": {
+    "build:watch": "tsc --watch",
+    "build": "tsc ",
+    "lint": "eslint ./src/**/*.ts"
+  },
+  "bugs": {
+    "url": "https://github.com/LeavittSoftware/titanium-elements/issues"
+  }
+}

--- a/packages/titanium-duration-input/package.json
+++ b/packages/titanium-duration-input/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@material/mwc-textfield": "*",
-    "luxon": "3.0.3",
+    "dayjs": "1.11.5",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {

--- a/packages/titanium-duration-input/src/human-interval.ts
+++ b/packages/titanium-duration-input/src/human-interval.ts
@@ -1,0 +1,69 @@
+// https://github.com/agenda/human-interval
+// Does not support esm
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const units: any = {};
+units.second = 1000;
+units.minute = units.second * 60;
+units.hour = units.minute * 60;
+units.day = units.hour * 24;
+units.week = units.day * 7;
+units.month = units.day * 30;
+units.year = units.day * 365;
+
+const languageMap = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+};
+
+const swapLanguageToDecimals = time => {
+  const language = languageMap;
+  const languageMapRegex = new RegExp('(' + Object.keys(language).join('|') + ')', 'g');
+  const matches = time.match(languageMapRegex);
+  if (!matches) {
+    return time;
+  }
+
+  matches.forEach(match => {
+    const matchStr = language[match] > 1 ? language[match] : language[match].toString().slice(1);
+    time = time.replace(match, matchStr);
+  });
+  return time;
+};
+
+const processUnits = time => {
+  if (time.match(/(second|minute|hour|day|week|month|year)s?/) === null) {
+    return undefined;
+  }
+
+  const num = parseFloat(time) || 1;
+  const unit = time.match(/(second|minute|hour|day|week|month|year)s?/)[1];
+
+  return units[unit] * num;
+};
+
+const humanInterval = time => {
+  if (!time) {
+    return time;
+  }
+
+  if (typeof time === 'number') {
+    return time;
+  }
+
+  time = swapLanguageToDecimals(time);
+  time = time.replace(/(second|minute|hour|day|week|month|year)s?(?! ?(s )?and |s?$)/, '$1,');
+  return time.split(/and|,/).reduce((sum, group) => sum + (group ? processUnits(group) : 0), 0);
+};
+
+humanInterval.languageMap = languageMap;
+
+export default humanInterval;

--- a/packages/titanium-duration-input/src/titanium-duration-input.ts
+++ b/packages/titanium-duration-input/src/titanium-duration-input.ts
@@ -1,0 +1,150 @@
+import { html, LitElement } from 'lit';
+import { property, customElement, query } from 'lit/decorators.js';
+
+import '@material/mwc-textfield';
+import { TextField } from '@material/mwc-textfield';
+import { Duration } from 'luxon';
+import humanInterval from './human-interval';
+
+/**
+ * Human readable duration input
+ *
+ * @element titanium-duration-input
+ *
+ *
+ */
+
+const TICKS_PER_MILLISECOND = 10000;
+
+@customElement('titanium-duration-input')
+export class TitaniumDurationInputElement extends LitElement {
+  /**
+   * Main input value
+   */
+  @property({ type: String }) value: string | null | undefined;
+
+  /**
+   *  Displays error state if value is empty and input is blurred.
+   */
+  @property({ type: Boolean }) required: boolean;
+
+  /**
+   * Disables the input
+   */
+  @property({ type: Boolean }) disabled: boolean;
+
+  /**
+   * Disables the input
+   */
+  @property({ type: Boolean }) helperPersistent: boolean;
+
+  /**
+   *  Message to show in the error color when the textfield is invalid. (Helper text will not be visible)
+   */
+  @property({ type: String }) validationMessage: string;
+
+  /**
+   *  helper text displayed to user
+   */
+  @property({ type: String }) helper: string = 'Enter a duration e.g. "3 hours and 30 minutes"';
+
+  /**
+   *  Sets floating label value.
+   */
+  @property({ type: String }) label: string = '';
+
+  /**
+   *  Sets icon value.
+   */
+  @property({ type: String }) icon: string = '';
+
+  @query('mwc-textfield') private input!: TextField & { mdcFoundation: { setValid(): boolean }; isUiValid: boolean };
+
+  firstUpdated() {
+    this.input.validityTransform = (newValue, nativeValidity) => {
+      if (!nativeValidity.valid) {
+        return {};
+      } else {
+        const len = newValue?.length ?? 0;
+        const isValid = (len > 6 && len < 12) || (len === 0 && !this.required);
+        return {
+          valid: isValid,
+          customError: !isValid,
+        };
+      }
+    };
+  }
+
+  #getReadableTime(time: number): string {
+    console.log(time);
+    try {
+      const units = Object.entries(
+        Duration.fromMillis(time / TICKS_PER_MILLISECOND)
+          .shiftTo('years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds')
+          .toObject()
+      );
+      return units
+        .filter(value => value[1] !== 0)
+        .map(value => `${value[1]} ${value[1] === 1 ? value[0].slice(0, -1) : value[0]}`)
+        .join(' and ');
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   *  Runs layout() method on textfield.
+   */
+  layout() {
+    this.input.layout();
+  }
+
+  /**
+   *  Runs checkValidity() method, and if it returns false, then it reports to the user that the input is invalid.
+   */
+  reportValidity() {
+    return this.input.reportValidity();
+  }
+
+  /**
+   *  Returns true if the input passes validity checks.
+   */
+  checkValidity() {
+    return this.input.checkValidity();
+  }
+
+  /**
+   *  Resets the inputs state.
+   */
+  reset() {
+    this.input.isUiValid = true;
+    this.input.mdcFoundation?.setValid?.(true);
+  }
+
+  render() {
+    return html`
+      <mwc-textfield
+        .label=${this.label}
+        .required=${this.required}
+        .validationMessage=${this.validationMessage}
+        .icon=${this.icon}
+        outlined
+        helper=${this.helper}
+        .value=${this.value ? this.#getReadableTime(Number(this.value)) : ''}
+        @change=${event => {
+          const millis = humanInterval(event.target.value);
+          if (millis && !isNaN(millis)) {
+            this.value = String(millis * TICKS_PER_MILLISECOND);
+            this.dispatchEvent(new CustomEvent('changed', { bubbles: true, composed: true }));
+          }
+        }}
+        .validityTransform=${(newValue, nativeValidity) => {
+          const millis = humanInterval(newValue);
+          return {
+            valid: !isNaN(millis) && nativeValidity?.valid,
+          };
+        }}
+      ></mwc-textfield>
+    `;
+  }
+}

--- a/packages/titanium-duration-input/src/titanium-duration-input.ts
+++ b/packages/titanium-duration-input/src/titanium-duration-input.ts
@@ -59,12 +59,12 @@ export class TitaniumDurationInputElement extends TextField {
     }
 
     return Object.entries({
-      years: d.get('years'),
-      weeks: d.get('weeks'),
-      days: d.get('days'),
-      hours: d.get('hours'),
-      minutes: d.get('minutes'),
-      seconds: d.get('seconds'),
+      years: d.years(),
+      months: d.months(),
+      days: d.days(),
+      hours: d.hours(),
+      minutes: d.minutes(),
+      seconds: d.seconds(),
     })
       .filter(value => value[1] !== 0)
       .map(value => `${value[1]} ${value[1] === 1 ? value[0].slice(0, -1) : value[0]}`)

--- a/packages/titanium-duration-input/src/titanium-duration-input.ts
+++ b/packages/titanium-duration-input/src/titanium-duration-input.ts
@@ -4,6 +4,7 @@ import { TextField } from '@material/mwc-textfield';
 import humanInterval from './human-interval';
 import dayjs from 'dayjs/esm';
 import duration from 'dayjs/esm/plugin/duration';
+import { PropertyValues } from 'lit';
 dayjs.extend(duration);
 
 /**
@@ -13,7 +14,7 @@ dayjs.extend(duration);
  *
  * @element titanium-duration-input
  *
- * @fires duration-changed The duration can be accessed via event.target.duration
+ * @fires duration-change The duration can be accessed via event.target.duration
  *
  */
 
@@ -36,13 +37,17 @@ export class TitaniumDurationInputElement extends TextField {
     this.addEventListener('change', () => {
       const millis = humanInterval(this.value);
       this.duration = isNaN(millis) ? null : dayjs.duration(millis, 'ms');
-      this.dispatchEvent(new CustomEvent('duration-changed', { bubbles: true, composed: true }));
+      this.dispatchEvent(new CustomEvent('duration-change', { bubbles: true, composed: true }));
     });
   }
 
-  firstUpdated() {
-    super.firstUpdated();
-    this.value = this.duration ? this._getReadableTime(this.duration) : '';
+  updated(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('duration') && changedProperties.get('duration') !== this.duration) {
+      if (this.duration) {
+        this.value = this._getReadableTime(this.duration);
+        this.layout();
+      }
+    }
   }
 
   private _getReadableTime(d: duration.Duration | null | undefined): string {

--- a/packages/titanium-duration-input/src/titanium-duration-input.ts
+++ b/packages/titanium-duration-input/src/titanium-duration-input.ts
@@ -44,13 +44,16 @@ export class TitaniumDurationInputElement extends TextField {
   updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('duration') && changedProperties.get('duration') !== this.duration) {
       if (this.duration) {
-        this.value = this._getReadableTime(this.duration);
+        this.value = this.#getReadableTime(this.duration);
         this.layout();
       }
     }
   }
 
-  private _getReadableTime(d: duration.Duration | null | undefined): string {
+  /**
+   * @ignore
+   */
+  #getReadableTime(d: duration.Duration | null | undefined): string {
     if (d === null || d === undefined) {
       return '';
     }

--- a/packages/titanium-duration-input/tsconfig.json
+++ b/packages/titanium-duration-input/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../base.tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "declarationDir": "lib"
+  },
+  "include": ["src/*.ts"]
+}

--- a/packages/titanium-duration-input/tsconfig.json
+++ b/packages/titanium-duration-input/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "declarationDir": "lib"
+    "declarationDir": "lib",
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,8 @@
     { "path": "packages/titanium-twoline-formfield" },
     { "path": "packages/titanium-shadow-text" },
     { "path": "packages/titanium-color-input" },
-    { "path": "packages/titanium-show-hide" }
+    { "path": "packages/titanium-show-hide" },
+    { "path": "packages/titanium-duration-input" }
   ],
   "files": []
 }


### PR DESCRIPTION
closes #411

Reworked the duration input to have a simpler API.
Input should just be duration in and duration out.
Replaced luxon with dayjs.
Extend textfield instead of encapsulate to reduce boilerplate
