### PR TITLE
413 titanium-attachment-input: "delete" icon doesn't look disabled when the rest of the component is disabled

### DIFF
--- a/packages/leavittbook/src/demos/titanium-attachment-input/titanium-attachment-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-attachment-input/titanium-attachment-input-playground.ts
@@ -16,6 +16,7 @@ export class TitaniumAttachmentInputPlayground extends LitElement {
   @state() private hasChanges: boolean = false;
   @query('titanium-attachment-input[get-files]') private getFilesInput!: TitaniumAttachmentInputElement;
   @query('titanium-attachment-input[preselect]') private preselectFilesInput!: TitaniumAttachmentInputElement;
+  @query('titanium-attachment-input[preselect-disabled]') private preselectDisabledFileInput!: TitaniumAttachmentInputElement;
   @query('titanium-attachment-input[reset]') private resetInput!: TitaniumAttachmentInputElement;
 
   static styles = [
@@ -43,6 +44,7 @@ export class TitaniumAttachmentInputPlayground extends LitElement {
 
   firstUpdated() {
     this.preselectFilesInput.setAttachment({ Id: 3, Name: 'preselected', Extension: 'png' });
+    this.preselectDisabledFileInput.setAttachment({ Id: 3, Name: 'preselected', Extension: 'png' });
   }
 
   render() {
@@ -71,6 +73,7 @@ export class TitaniumAttachmentInputPlayground extends LitElement {
       <p>populate input with pre selected attachments (using setAttachment in firstUpdated)</p>
       <div>
         <titanium-attachment-input multiple placeholder="Select Files" preselect></titanium-attachment-input>
+        <titanium-attachment-input multiple placeholder="Select Files" preselect-disabled disabled></titanium-attachment-input>
       </div>
 
       <h1>Has Changes</h1>

--- a/packages/titanium-attachment-input/src/titanium-attachment-input.ts
+++ b/packages/titanium-attachment-input/src/titanium-attachment-input.ts
@@ -185,6 +185,7 @@ export class TitaniumAttachmentInputElement extends LitElement {
       :host([disabled]) attachment-input {
         border-color: rgba(0, 0, 0, 0.06);
         color: rgba(0, 0, 0, 0.06);
+        --mdc-theme-text-disabled-on-light: rgba(0, 0, 0, 0.06);
       }
 
       :host(:not([disabled])) attachment-input:hover {


### PR DESCRIPTION
closes #413 

![localhost_8000_titanium-attachment-input](https://user-images.githubusercontent.com/5438655/196475952-07df5d06-d3cf-4cae-b458-31c665363c7f.png)

