### PR TITLE
fix(titanium-dialog): prevent esc key from closing dialogs that are focus trapped

### DIFF
--- a/packages/leavittbook/src/demos/titanium-dialog-base/titanium-dialog-base-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-dialog-base/titanium-dialog-base-playground.ts
@@ -54,7 +54,7 @@ export class TitaniumDialogPlayground extends LitElement {
       <div>
         <h1>Default</h1>
         <p>titanium-native-dialog-base with no configuration set</p>
-        <mwc-button @click=${() => this.defaultDialog?.open()} label="Fake Donation"></mwc-button>
+        <mwc-button @click=${async () => alert('Close reason:' + (await this.defaultDialog?.open()))} label="Fake Donation"></mwc-button>
 
         <titanium-native-dialog-base default>
           <main style="background: aliceblue;padding: 24px;">
@@ -67,11 +67,11 @@ export class TitaniumDialogPlayground extends LitElement {
       <div>
         <h1>Focus Trap</h1>
         <p>titanium-native-dialog-base with the focus-trap attribute applied - this will prevent tabbing outside of the dialog</p>
-        <mwc-button @click=${() => this.focusTrapDialog?.open()} label="Tarzan of the Apes"></mwc-button>
+        <mwc-button @click=${async () => alert('Close reason:' + (await this.focusTrapDialog?.open()))} label="Tarzan of the Apes"></mwc-button>
 
         <titanium-native-dialog-base focus-trap>
           <custom-container>
-            <mwc-button @click=${() => this.focusTrapDialog?.close()} label="Only one way to close"></mwc-button>
+            <mwc-button @click=${() => this.focusTrapDialog?.close('button')} label="Only one way to close"></mwc-button>
           </custom-container>
         </titanium-native-dialog-base>
       </div>

--- a/packages/titanium-dialog/src/titanium-native-dialog-base.ts
+++ b/packages/titanium-dialog/src/titanium-native-dialog-base.ts
@@ -117,6 +117,10 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
     }
   }
 
+  protected closeDialog = () => {
+    this.close('navigate-away');
+  };
+
   protected async dialogClose({ target: dialog }) {
     dialog.setAttribute('inert', '');
     dialog.dispatchEvent(new Event('closing'));
@@ -133,6 +137,7 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
   open() {
     return new Promise<string>(resolve => {
       this._resolve = resolve;
+      window.addEventListener('popstate', this.closeDialog, false);
       this.dialog.showModal();
     });
   }
@@ -154,6 +159,7 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
     if (!this.dialog.open) {
       return;
     }
+    window.removeEventListener('popstate', this.closeDialog);
     this.dialog.close(reason);
 
     this._resolve(reason);

--- a/packages/titanium-dialog/src/titanium-native-dialog-base.ts
+++ b/packages/titanium-dialog/src/titanium-native-dialog-base.ts
@@ -58,6 +58,7 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
 
     this.dialog.addEventListener('click', this.lightDismiss);
     this.dialog.addEventListener('close', this.dialogClose);
+    this.dialog.addEventListener('cancel', this.onCancel);
 
     this.dialogAttrObserver.observe(this.dialog, {
       attributes: true,
@@ -105,6 +106,7 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
         if (removedNode.nodeName === 'DIALOG') {
           removedNode.removeEventListener('click', this.lightDismiss);
           removedNode.removeEventListener('close', this.dialogClose);
+          removedNode.removeEventListener('cancel', this.onCancel);
           removedNode.dispatchEvent(new Event('removed'));
         }
       });
@@ -116,6 +118,14 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
       dialog.close('backdrop');
     }
   }
+
+  protected onCancel = (e: Event) => {
+    e.preventDefault();
+
+    if (!this.focusTrap) {
+      this.close('cancel');
+    }
+  };
 
   protected closeDialog = () => {
     this.close('navigate-away');


### PR DESCRIPTION
Emit a reason for closed dialogs that are canceled (via esc key)