### PR TITLE
417 Find a way to make chips with and without icons and images line up in a inline container

### DIFF
--- a/packages/leavittbook/src/demos/titanium-chip/titanium-chip-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-chip/titanium-chip-playground.ts
@@ -31,6 +31,14 @@ export class TitaniumChipPlayground extends LitElement {
         gap: 12px;
         margin: 24px 0 36px 0;
       }
+
+      span {
+        border: 1px solid var(--app-border-color);
+        padding: 24px;
+        border-radius: 8px;
+        gap: 12px;
+        margin: 24px 0 36px 0;
+      }
     `,
   ];
 
@@ -66,6 +74,14 @@ export class TitaniumChipPlayground extends LitElement {
         <titanium-chip label="Offline"> <mwc-icon slot="chip-icon">offline_bolt</mwc-icon></titanium-chip>
         <titanium-chip label="Online"> <mwc-icon slot="chip-icon">bolt</mwc-icon></titanium-chip>
       </div>
+
+      <h1>Variable type</h1>
+      <p>Examples using various chip types together without a flex container</p>
+      <span>
+        <titanium-chip label="The Rock"><profile-picture slot="chip-icon" personId="915608" size="28"></profile-picture ></profile-picture></titanium-chip>
+        <titanium-chip label="Online"> <mwc-icon slot="chip-icon">bolt</mwc-icon></titanium-chip>
+        <titanium-chip label="Default"></titanium-chip>
+      </span>
     `;
   }
 }

--- a/packages/titanium-chip/src/titanium-chip.ts
+++ b/packages/titanium-chip/src/titanium-chip.ts
@@ -123,6 +123,7 @@ export class TitaniumChipElement extends LitElement implements CheckableElement 
   static styles = css`
     :host {
       display: inline-flex;
+      vertical-align: bottom;
       flex-direction: row;
       align-items: center;
       position: relative;


### PR DESCRIPTION
closes #417

**Before**
![ChipsBefore](https://user-images.githubusercontent.com/20712428/200936865-f037de2c-dc63-4c0e-a958-17dd59e9eccc.png)

**After**
![ChipsAfter](https://user-images.githubusercontent.com/20712428/200936861-0876e065-cc88-4cbb-b79c-77b246937198.png)
