### PR TITLE
440 In MWC Datefield check if safari and hide the icon to prevent the click autoclose of the date picker problem

### DIFF
--- a/packages/leavitt-elements/package.json
+++ b/packages/leavitt-elements/package.json
@@ -20,7 +20,8 @@
     "@material/mwc-textfield": "*",
     "dayjs": "*",
     "fuse.js": "*",
-    "tslib": "^2.4.1"
+    "tslib": "^2.4.1",
+    "bowser": "*"
   },
   "peerDependencies": {
     "lit": ">=2.5.0"

--- a/packages/leavitt-elements/src/mwc-datefield.ts
+++ b/packages/leavitt-elements/src/mwc-datefield.ts
@@ -3,6 +3,7 @@ import { css } from 'lit';
 import { TextField } from '@material/mwc-textfield';
 import { property, customElement } from 'lit/decorators.js';
 import { NotchedOutline } from '@material/mwc-notched-outline';
+import Bowser from 'bowser';
 
 /**
  *  Date/Time Field input that extends mwc TextField
@@ -21,6 +22,13 @@ export class DateField extends TextField {
     if (changedProps.has('dateType')) {
       this.placeholder = this.dateType === 'date' ? 'yyyy-mm-dd' : 'yyyy-mm-dd MM:hh:ss';
       this.type = this.dateType;
+    }
+  }
+
+  firstUpdated() {
+    const bowser = Bowser.getParser(window.navigator.userAgent);
+    if (bowser.getBrowserName(true) === 'safari') {
+      this.iconTrailing = '';
     }
   }
 

--- a/packages/leavitt-elements/src/mwc-datefield.ts
+++ b/packages/leavitt-elements/src/mwc-datefield.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { css } from 'lit';
 import { TextField } from '@material/mwc-textfield';
 import { property, customElement } from 'lit/decorators.js';
 import { NotchedOutline } from '@material/mwc-notched-outline';
@@ -62,23 +61,5 @@ export class DateField extends TextField {
      *  @ignore
      */
     this.max = '2999-12-31';
-  }
-
-  static get styles() {
-    return [
-      css`
-        input::-webkit-calendar-picker-indicator {
-          display: block !important;
-          position: absolute;
-          top: 0;
-          right: 0;
-          opacity: 0;
-          width: 48px;
-          height: 100%;
-          cursor: pointer;
-        }
-      `,
-      ...super.styles,
-    ] as any;
   }
 }


### PR DESCRIPTION
closes #440 

This is a temporary fix until material 3 components arrive. Also removes old style code that isn't needed anymore
