### PR TITLE
449 searching with more than 3 tokens in the data table doesn't sanitize the search input ('&' will break odata)

### DIFF
--- a/packages/titanium-helpers/src/titanium-search-token.ts
+++ b/packages/titanium-helpers/src/titanium-search-token.ts
@@ -11,7 +11,7 @@ export const getSearchTokens = (inputText: string, allowedComplexityLevel = 3) =
   if (tokens.length > allowedComplexityLevel) {
     // if user types more than
     // three words, do not tokenize
-    tokens = [inputText.trim()];
+    tokens = [escapeTerm(inputText.trim())];
   }
   return tokens;
 };


### PR DESCRIPTION
closes #449
