### PR TITLE
fix(leavitt-elements): move event bus callbacks out of dispatching stack

### DIFF
--- a/packages/leavitt-elements/src/event-bus.ts
+++ b/packages/leavitt-elements/src/event-bus.ts
@@ -57,6 +57,10 @@ export class EventBus<TEntityTypes, TEventTypes> {
   }
 
   dispatch<TArg>(entityType: TEntityTypes, eventTypes: TEventTypes, object?: TArg) {
-    this.#subscribers.filter(s => s.entityType === entityType && (s.eventTypes === 'All' || s.eventTypes === eventTypes)).forEach(s => s.callback(object));
+    setTimeout(
+      () =>
+        this.#subscribers.filter(s => s.entityType === entityType && (s.eventTypes === 'All' || s.eventTypes === eventTypes)).forEach(s => s.callback(object)),
+      0
+    );
   }
 }


### PR DESCRIPTION
Fixes issue where we dispatch an event from inside a try-catch and any error in any matching callback on any loaded page gets grabbed, making it really hard to find out where the problem actually is.