### PR TITLE
fix: remove explicit max height on file modal

### DIFF
--- a/packages/leavitt-file-explorer/src/leavitt-file-modal.ts
+++ b/packages/leavitt-file-explorer/src/leavitt-file-modal.ts
@@ -43,7 +43,6 @@ export class LeavittFileModalElement extends LitElement {
     :host {
       display: block;
       --titanium-dialog-max-width: 850px;
-      --titanium-dialog-max-height: 850px;
     }
   `;
 


### PR DESCRIPTION
Installed version of dialog on Apps.leavitt.com did not pass in `--titanium-dialog-max-height`, with update the explicit height is causing modal to overflow window on laptop screens. 

![image](https://user-images.githubusercontent.com/18709288/231228791-bdf54b0a-1e65-4863-852e-0bb36f25c919.png)
