### PR TITLE
Allow for more button configuration

### DIFF
--- a/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
@@ -161,8 +161,8 @@ export class TitaniumColorInputPlayground extends LitElement {
         left: -2px;
       }
 
-      titanium-show-hide[start] {
-        --titanium-show-hide-button-alignment: start;
+      titanium-show-hide[start]::part(button) {
+        align-self: start;
       }
     `,
   ];
@@ -263,7 +263,7 @@ export class TitaniumColorInputPlayground extends LitElement {
       <h1>Show hide text</h1>
       <p>Reveal some more text. Sets custom collapsed/expanded text and custom button alignment.</p>
       <div main>
-        <titanium-show-hide start buttonType="flat" collapsedText="Read more" expandedText="Read less">
+        <titanium-show-hide start buttonType="flat" collapsedButtonLabel="Read more" expandedButtonLabel="Read less">
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum arcu, semper ac aliquet eu, porttitor vel turpis. Nullam non dolor ac massa
             pharetra vulputate vel ac libero. In hac habitasse platea dictumst. Praesent lacus mi, vehicula eu euismod sit amet, accumsan porta massa. Morbi

--- a/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
@@ -160,6 +160,10 @@ export class TitaniumColorInputPlayground extends LitElement {
         position: absolute;
         left: -2px;
       }
+
+      titanium-show-hide[start] {
+        --titanium-show-hide-button-alignment: start;
+      }
     `,
   ];
 
@@ -254,6 +258,31 @@ export class TitaniumColorInputPlayground extends LitElement {
               <card-number>${dayjs().format('MM/YY')}</card-number>
             </credit-card>`
           )}
+        </titanium-show-hide>
+      </div>
+      <h1>Show hide text</h1>
+      <p>Reveal some more text. Sets custom collapsed/expanded text and custom button alignment.</p>
+      <div main>
+        <titanium-show-hide start buttonType="flat" collapsedText="Read more" expandedText="Read less">
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum arcu, semper ac aliquet eu, porttitor vel turpis. Nullam non dolor ac massa
+            pharetra vulputate vel ac libero. In hac habitasse platea dictumst. Praesent lacus mi, vehicula eu euismod sit amet, accumsan porta massa. Morbi
+            nibh odio, pellentesque sit amet nulla sit amet, pellentesque mattis felis. Donec in eros sit amet lectus maximus porttitor. Morbi iaculis velit sed
+            interdum venenatis. Suspendisse ac consectetur tellus. Fusce molestie nunc ac dui sollicitudin, at sagittis dui convallis. Orci varius natoque
+            penatibus et magnis dis parturient montes, nascetur ridiculus mus. Proin euismod nisl et risus malesuada, non fermentum diam pharetra. Sed accumsan
+            diam turpis, aliquet viverra quam molestie viverra. Nam ullamcorper commodo dictum. Cras bibendum odio vel tortor sodales porttitor ac nec ligula.
+            Praesent eget tellus vitae diam vehicula aliquam sit amet ut mi. Curabitur pretium, enim in lacinia vehicula, sapien metus ultrices eros, vitae
+            volutpat ex tortor nec lacus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed eget porttitor mi.
+            Suspendisse sed dolor non justo euismod volutpat. Nulla massa quam, dignissim sed dapibus ac, laoreet eu elit. Proin libero ipsum, blandit quis diam
+            non, vulputate faucibus risus. Sed tincidunt elit metus. Aliquam maximus fringilla erat, eget pretium erat. Maecenas euismod fringilla placerat.
+            Nunc lorem nulla, feugiat sagittis dolor id, scelerisque convallis risus. Nullam molestie, odio sed cursus convallis, nulla ligula gravida leo, ac
+            suscipit mi elit nec velit. Nulla euismod molestie accumsan. Suspendisse ut aliquet dolor. Sed vel mollis nisl, sit amet porta odio. Vivamus
+            sagittis metus vulputate enim porttitor rhoncus. Ut facilisis ligula eget lorem rhoncus, vel pretium mauris cursus. Cras vel condimentum odio. Fusce
+            vehicula facilisis risus, in maximus ante suscipit sed. Sed ac quam a nisl hendrerit tempor varius sed mauris. Donec tempor mauris et nisi sagittis
+            laoreet. Sed dapibus ex non consectetur maximus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aenean arcu
+            neque, molestie a nisi vel, tincidunt vehicula arcu. Ut ut lectus gravida, tristique mauris a, aliquet magna. Duis sodales in ipsum pretium
+            hendrerit.
+          </p>
         </titanium-show-hide>
       </div>
     `;

--- a/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
@@ -263,7 +263,7 @@ export class TitaniumColorInputPlayground extends LitElement {
       <h1>Show hide text</h1>
       <p>Reveal some more text. Sets custom collapsed/expanded text and custom button alignment.</p>
       <div main>
-        <titanium-show-hide start buttonType="flat" collapsedButtonLabel="Read more" expandedButtonLabel="Read less">
+        <titanium-show-hide start buttonType="flat" .showCountWithLabel=${false} collapsedButtonLabel="Read more" expandedButtonLabel="Read less">
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ipsum arcu, semper ac aliquet eu, porttitor vel turpis. Nullam non dolor ac massa
             pharetra vulputate vel ac libero. In hac habitasse platea dictumst. Praesent lacus mi, vehicula eu euismod sit amet, accumsan porta massa. Morbi

--- a/packages/titanium-show-hide/src/titanium-show-hide.ts
+++ b/packages/titanium-show-hide/src/titanium-show-hide.ts
@@ -121,7 +121,7 @@ export default class TitaniumShowHideElement extends LitElement {
         @click=${() => (this.collapsed = !this.collapsed)}
         ?hidden=${!this.hasHiddenItems}
       >
-        ${this.collapsed ? this.collapsedButtonLabel : this.expandedButtonLabel}</mwc-button
+        ${this.collapsed ? `${this.collapsedButtonLabel} ${this.showCountWithLabel ? `(${this.hiddenItemCount})` : ''}` : this.expandedButtonLabel}</mwc-button
       >
     `;
   }

--- a/packages/titanium-show-hide/src/titanium-show-hide.ts
+++ b/packages/titanium-show-hide/src/titanium-show-hide.ts
@@ -15,6 +15,7 @@ import '@material/mwc-button';
  * @cssprop [--titanium-show-hide-flex-direction=column] - flex direction for the parent of the slotted in content
  * @cssprop [--titanium-show-hide-flex-wrap=wrap] - flex wrap for the parent of the slotted in content
  * @cssprop [--titanium-show-hide-gap=8px] - flex direction of the for the parent of the slotted in content
+ * @cssprop [--titanium-show-hide-button-alignment=center] - flex alignment of the button
  */
 @customElement('titanium-show-hide')
 export default class TitaniumShowHideElement extends LitElement {
@@ -27,6 +28,9 @@ export default class TitaniumShowHideElement extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'disable-fade' }) disableFade: boolean = false;
   @property({ type: Boolean, reflect: true, attribute: 'collapsed' }) collapsed: boolean = true;
   @property({ type: Boolean, reflect: true, attribute: 'has-hidden-items' }) protected hasHiddenItems: boolean = false;
+  @property({ type: String }) collapsedText: string;
+  @property({ type: String }) expandedText: string;
+  @property({ type: String }) buttonType: 'flat' | 'raised' | 'unelevated' | 'outlined' = 'outlined';
 
   @state() protected hiddenItemCount: number = 0;
   @query('items-container') protected itemsContainer: HTMLElement;
@@ -86,7 +90,7 @@ export default class TitaniumShowHideElement extends LitElement {
       }
 
       mwc-button {
-        align-self: center;
+        align-self: var(--titanium-show-hide-button-alignment, center);
         margin-top: 12px;
       }
 
@@ -108,8 +112,22 @@ export default class TitaniumShowHideElement extends LitElement {
           <slot></slot>
         </items-container>
       </collapsed-box>
-      <mwc-button part="button" outlined lowercase @click=${() => (this.collapsed = !this.collapsed)} ?hidden=${!this.hasHiddenItems}>
-        ${this.collapsed ? `Show more (${this.hiddenItemCount})` : 'Show less'}</mwc-button
+      <mwc-button
+        .outlined=${this.buttonType === 'outlined'}
+        .raised=${this.buttonType === 'raised'}
+        .unelevated=${this.buttonType === 'unelevated'}
+        part="button"
+        lowercase
+        @click=${() => (this.collapsed = !this.collapsed)}
+        ?hidden=${!this.hasHiddenItems}
+      >
+        ${this.collapsed
+          ? this.collapsedText
+            ? this.collapsedText
+            : `Show more (${this.hiddenItemCount})`
+          : this.expandedText
+          ? this.expandedText
+          : 'Show less'}</mwc-button
       >
     `;
   }

--- a/packages/titanium-show-hide/src/titanium-show-hide.ts
+++ b/packages/titanium-show-hide/src/titanium-show-hide.ts
@@ -15,7 +15,6 @@ import '@material/mwc-button';
  * @cssprop [--titanium-show-hide-flex-direction=column] - flex direction for the parent of the slotted in content
  * @cssprop [--titanium-show-hide-flex-wrap=wrap] - flex wrap for the parent of the slotted in content
  * @cssprop [--titanium-show-hide-gap=8px] - flex direction of the for the parent of the slotted in content
- * @cssprop [--titanium-show-hide-button-alignment=center] - flex alignment of the button
  */
 @customElement('titanium-show-hide')
 export default class TitaniumShowHideElement extends LitElement {
@@ -28,8 +27,9 @@ export default class TitaniumShowHideElement extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'disable-fade' }) disableFade: boolean = false;
   @property({ type: Boolean, reflect: true, attribute: 'collapsed' }) collapsed: boolean = true;
   @property({ type: Boolean, reflect: true, attribute: 'has-hidden-items' }) protected hasHiddenItems: boolean = false;
-  @property({ type: String }) collapsedText: string;
-  @property({ type: String }) expandedText: string;
+  @property({ type: String }) collapsedButtonLabel: string = 'Show more';
+  @property({ type: String }) expandedButtonLabel: string = 'Show less';
+  @property({ type: Boolean }) showCountWithLabel: boolean = true;
   @property({ type: String }) buttonType: 'flat' | 'raised' | 'unelevated' | 'outlined' = 'outlined';
 
   @state() protected hiddenItemCount: number = 0;
@@ -90,7 +90,7 @@ export default class TitaniumShowHideElement extends LitElement {
       }
 
       mwc-button {
-        align-self: var(--titanium-show-hide-button-alignment, center);
+        align-self: center;
         margin-top: 12px;
       }
 
@@ -121,13 +121,7 @@ export default class TitaniumShowHideElement extends LitElement {
         @click=${() => (this.collapsed = !this.collapsed)}
         ?hidden=${!this.hasHiddenItems}
       >
-        ${this.collapsed
-          ? this.collapsedText
-            ? this.collapsedText
-            : `Show more (${this.hiddenItemCount})`
-          : this.expandedText
-          ? this.expandedText
-          : 'Show less'}</mwc-button
+        ${this.collapsed ? this.collapsedButtonLabel : this.expandedButtonLabel}</mwc-button
       >
     `;
   }

--- a/packages/titanium-side-menu/src/titanium-side-menu-item.ts
+++ b/packages/titanium-side-menu/src/titanium-side-menu-item.ts
@@ -104,6 +104,6 @@ export class TitaniumSideMenuItemElement extends LitElement {
   `;
 
   render() {
-    return html` <a href=${this.href} target=${ifDefined(this.target)}><slot></slot></a> `;
+    return html` <a part="anchor" href=${this.href} target=${ifDefined(this.target)}><slot></slot></a> `;
   }
 }


### PR DESCRIPTION
allow for custom text, alignment, and button type

This will allow for the directory and recruiting sites to use titanium-show-hide instead of a local component.
Thank you for your consideration.