### PR TITLE
fix(leavitt-elements): use actual whitespace character for placeholder icon

### DIFF
--- a/packages/leavitt-elements/src/leavitt-company-select.ts
+++ b/packages/leavitt-elements/src/leavitt-company-select.ts
@@ -311,7 +311,7 @@ export class LeavittCompanyElement extends LoadWhile(LitElement) {
     return html`
       <mwc-textfield
         outlined
-        icon=${this.selected?.Id ? 'l' : this.icon}
+        icon=${this.selected?.Id ? ' ' : this.icon}
         .label=${this.label}
         .disabled=${this.disabled}
         .placeholder=${this.placeholder}

--- a/packages/leavitt-elements/src/leavitt-person-company-select.ts
+++ b/packages/leavitt-elements/src/leavitt-person-company-select.ts
@@ -333,7 +333,7 @@ export class LeavittPersonCompanySelectElement extends LoadWhile(LitElement) {
     return html`
       <mwc-textfield
         outlined
-        icon=${this.selected ? 'l' : 'search'}
+        icon=${this.selected ? ' ' : 'search'}
         .label=${this.label}
         .disabled=${this.disabled}
         .placeholder=${this.placeholder}

--- a/packages/leavitt-elements/src/mwc-datefield.ts
+++ b/packages/leavitt-elements/src/mwc-datefield.ts
@@ -32,7 +32,7 @@ export class DateField extends TextField {
       //Chrome mobile get normal mwc training icon
       //Chrome desktop gets native calendar icon positioned over blank reserved icon space
       //FF && Safari bring unstyled native calendar icons
-      this.iconTrailing = bowser.getPlatformType() === 'mobile' ? 'event' : 'a';
+      this.iconTrailing = bowser.getPlatformType() === 'mobile' ? 'event' : ' ';
     }
   }
 


### PR DESCRIPTION
Allows using icon fonts that have characters for letters. Such as the new Material Symbols font.