### PR TITLE
fix: Allow flexibility for height/alignment on input validator

### DIFF
--- a/packages/titanium-input-validator/src/titanium-input-validator.ts
+++ b/packages/titanium-input-validator/src/titanium-input-validator.ts
@@ -69,6 +69,9 @@ export class TitaniumInputValidator extends LitElement {
     outlined-container {
       display: flex;
       flex-direction: column;
+      height: inherit;
+      align-items: inherit;
+      justify-content: inherit;
       border: 1px solid var(--mdc-text-field-outlined-idle-border-color, rgba(0, 0, 0, 0.38));
       border-radius: 4px;
       position: relative;


### PR DESCRIPTION
specifying height and alignment props on the host styles will now be applied to outlined-container as well
