### PR TITLE
fix(titanium-dialog): fix dialogs centering on 0,0 in safari

### DIFF
--- a/packages/titanium-dialog/src/titanium-native-dialog-base.ts
+++ b/packages/titanium-dialog/src/titanium-native-dialog-base.ts
@@ -193,7 +193,6 @@ export class TitaniumNativeDialogBaseElement extends LitElement {
 
         overflow: initial;
 
-        position: fixed;
         top: 0;
         bottom: 0;
         left: 0;


### PR DESCRIPTION
With `position:fixed` and `container-type: inline-size` safari shoves the dialog off the top-left corner of the viewport.

Seems to work normally on all browsers without `position:fixed`. Native dialog should be using viewport coordinates by default anyway.