### PR TITLE
Use spa routing hack for github pages

### DIFF
--- a/packages/leavittbook/404.html
+++ b/packages/leavittbook/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/leavittbook/index.html
+++ b/packages/leavittbook/index.html
@@ -42,6 +42,22 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" defer async rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400" rel="stylesheet" />
 
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // https://github.com/rafgraph/spa-github-pages
+      (function(l) {
+        if (l.search[1] === '/' ) {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
+
     <script>
       //do not set ClaimScopes on sites with the manage side menu
       window.localStorage.setItem('LgClaimScopes', '["Unit Testing App"]');

--- a/packages/leavittbook/rollup.config.js
+++ b/packages/leavittbook/rollup.config.js
@@ -66,6 +66,7 @@ export default {
         { src: 'manifest', dest: 'dist' },
         { src: 'fonts', dest: 'dist' },
         { src: 'images', dest: 'dist' },
+        { src: '404.html', dest: 'dist' },
         { src: 'src/demos/*', dest: 'dist/src/demos' },
       ],
     }),


### PR DESCRIPTION
closes #516

SPA are NOT natively supported. This is a hack I want to try.
https://github.com/rafgraph/spa-github-pages

Here is the issue saying spa routing isn't supported by github pages. Their recommendations are to move to other free hosting services when a SPA is a requirement.
https://github.com/isaacs/github/issues/408
