### PR TITLE
543 add accessor on all decorators

### DIFF
--- a/packages/leavittbook/src/demos/available-cdn-icons/available-cdn-icons-demo.ts
+++ b/packages/leavittbook/src/demos/available-cdn-icons/available-cdn-icons-demo.ts
@@ -9,7 +9,7 @@ import '../../shared/smart-demo';
 import './available-cdn-icons-playground';
 
 @customElement('available-cdn-icons-demo')
-export class AvailableCdnIconsDemoElement extends LitElement {
+export class AvailableCdnIconsDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {

--- a/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-demo.ts
@@ -11,7 +11,7 @@ import './leavitt-company-select-playground';
 
 @customElement('leavitt-company-select-demo')
 export class LeavittCompanySelectDemoElement extends LitElement {
-  @state() refreshToken: string | null = null;
+  @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
 

--- a/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-demo.ts
@@ -10,7 +10,7 @@ import '../../shared/smart-demo';
 import './leavitt-company-select-playground';
 
 @customElement('leavitt-company-select-demo')
-export class LeavittCompanySelectDemoElement extends LitElement {
+export class LeavittCompanySelectDemo extends LitElement {
   @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
@@ -23,7 +23,7 @@ export class LeavittCompanySelectDemoElement extends LitElement {
 
   render() {
     return html`
-      <story-header name="Leavitt Company Select" packageName="leavitt-elements" className="LeavittCompanySelectElement"></story-header>
+      <story-header name="Leavitt Company Select" className="LeavittCompanySelect"></story-header>
       ${this.refreshToken
         ? html`<smart-demo
             html-file=${`index.html?#${encodeURIComponent(this.refreshToken)}`}

--- a/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-playground.ts
@@ -17,7 +17,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 /* playground-fold */
 @customElement('leavitt-company-select-playground')
 export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
-  @state() apiService: ApiService;
+  @state() private accessor apiService: ApiService;
   @query('leavitt-company-select[methods-demo]') protected accessor methodsSelect!: LeavittCompanySelect;
   @queryAll('leavitt-company-select') protected accessor inputs!: NodeListOf<LeavittCompanySelect>;
 

--- a/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-playground.ts
@@ -18,8 +18,8 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 @customElement('leavitt-company-select-playground')
 export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
   @state() apiService: ApiService;
-  @query('leavitt-company-select[methods-demo]') protected methodsSelect!: LeavittCompanySelect;
-  @queryAll('leavitt-company-select') protected inputs!: NodeListOf<LeavittCompanySelect>;
+  @query('leavitt-company-select[methods-demo]') protected accessor methodsSelect!: LeavittCompanySelect;
+  @queryAll('leavitt-company-select') protected accessor inputs!: NodeListOf<LeavittCompanySelect>;
 
   constructor() {
     super();

--- a/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-company-select/leavitt-company-select-playground.ts
@@ -16,7 +16,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 
 /* playground-fold */
 @customElement('leavitt-company-select-playground')
-export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
+export class LeavittPersonCompanySelectPlayground extends LitElement {
   @state() private accessor apiService: ApiService;
   @query('leavitt-company-select[methods-demo]') protected accessor methodsSelect!: LeavittCompanySelect;
   @queryAll('leavitt-company-select') protected accessor inputs!: NodeListOf<LeavittCompanySelect>;

--- a/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-demo.ts
@@ -10,7 +10,7 @@ import '../../shared/smart-demo';
 import './leavitt-person-company-select-playground';
 
 @customElement('leavitt-person-company-select-demo')
-export class LeavittPersonCompanySelectDemoElement extends LitElement {
+export class LeavittPersonCompanySelectDemo extends LitElement {
   @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
@@ -23,7 +23,7 @@ export class LeavittPersonCompanySelectDemoElement extends LitElement {
 
   render() {
     return html`
-      <story-header name="Leavitt Person/Company Select" packageName="leavitt-elements" className="LeavittPersonCompanySelectElement"></story-header>
+      <story-header name="Leavitt Person/Company Select" className="LeavittPersonCompanySelect"></story-header>
       ${this.refreshToken
         ? html`<smart-demo
             html-file=${`index.html?#${encodeURIComponent(this.refreshToken)}`}

--- a/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-demo.ts
@@ -11,7 +11,7 @@ import './leavitt-person-company-select-playground';
 
 @customElement('leavitt-person-company-select-demo')
 export class LeavittPersonCompanySelectDemoElement extends LitElement {
-  @state() refreshToken: string | null = null;
+  @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
 

--- a/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-playground.ts
@@ -14,7 +14,7 @@ import { LeavittPersonCompanySelect } from '@leavittsoftware/web/leavitt/person-
 
 /* playground-fold */
 @customElement('leavitt-person-company-select-playground')
-export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
+export class LeavittPersonCompanySelectPlayground extends LitElement {
   @state() private accessor apiService: ApiService;
   @queryAll('leavitt-person-company-select') protected accessor inputs!: NodeListOf<LeavittPersonCompanySelect>;
   @query('leavitt-person-company-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonCompanySelect;

--- a/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-playground.ts
@@ -15,7 +15,7 @@ import { LeavittPersonCompanySelect } from '@leavittsoftware/web/leavitt/person-
 /* playground-fold */
 @customElement('leavitt-person-company-select-playground')
 export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
-  @state() apiService: ApiService;
+  @state() private accessor apiService: ApiService;
   @queryAll('leavitt-person-company-select') protected accessor inputs!: NodeListOf<LeavittPersonCompanySelect>;
   @query('leavitt-person-company-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonCompanySelect;
 

--- a/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-company-select/leavitt-person-company-select-playground.ts
@@ -16,8 +16,8 @@ import { LeavittPersonCompanySelect } from '@leavittsoftware/web/leavitt/person-
 @customElement('leavitt-person-company-select-playground')
 export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
   @state() apiService: ApiService;
-  @queryAll('leavitt-person-company-select') protected inputs!: NodeListOf<LeavittPersonCompanySelect>;
-  @query('leavitt-person-company-select[methods-demo]') protected methodsSelect!: LeavittPersonCompanySelect;
+  @queryAll('leavitt-person-company-select') protected accessor inputs!: NodeListOf<LeavittPersonCompanySelect>;
+  @query('leavitt-person-company-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonCompanySelect;
 
   constructor() {
     super();

--- a/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-demo.ts
@@ -11,7 +11,7 @@ import './leavitt-person-group-select-playground';
 
 @customElement('leavitt-person-group-select-demo')
 export class LeavittPersonGroupSelectDemoElement extends LitElement {
-  @state() refreshToken: string | null = null;
+  @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
 

--- a/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-demo.ts
@@ -10,7 +10,7 @@ import '../../shared/smart-demo';
 import './leavitt-person-group-select-playground';
 
 @customElement('leavitt-person-group-select-demo')
-export class LeavittPersonGroupSelectDemoElement extends LitElement {
+export class LeavittPersonGroupSelectDemo extends LitElement {
   @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
@@ -23,7 +23,7 @@ export class LeavittPersonGroupSelectDemoElement extends LitElement {
 
   render() {
     return html`
-      <story-header name="Leavitt Person/Group Select" packageName="leavitt-elements" className="LeavittPersonGroupSelectElement"></story-header>
+      <story-header name="Leavitt Person/Group Select" className="LeavittPersonGroupSelect"></story-header>
       ${this.refreshToken
         ? html`<smart-demo
             html-file=${`index.html?#${encodeURIComponent(this.refreshToken)}`}

--- a/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-playground.ts
@@ -16,7 +16,7 @@ import { LeavittPersonGroupSelect } from '@leavittsoftware/web/leavitt/person-gr
 /* playground-fold */
 @customElement('leavitt-person-group-select-playground')
 export class LeavittPersonGroupSelectPlaygroundElement extends LitElement {
-  @state() apiService: ApiService;
+  @state() private accessor apiService: ApiService;
   @queryAll('leavitt-person-group-select)') protected accessor inputs!: NodeListOf<LeavittPersonGroupSelect>;
   @query('leavitt-person-group-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonGroupSelect;
 

--- a/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-playground.ts
@@ -15,7 +15,7 @@ import { LeavittPersonGroupSelect } from '@leavittsoftware/web/leavitt/person-gr
 
 /* playground-fold */
 @customElement('leavitt-person-group-select-playground')
-export class LeavittPersonGroupSelectPlaygroundElement extends LitElement {
+export class LeavittPersonGroupSelectPlayground extends LitElement {
   @state() private accessor apiService: ApiService;
   @queryAll('leavitt-person-group-select)') protected accessor inputs!: NodeListOf<LeavittPersonGroupSelect>;
   @query('leavitt-person-group-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonGroupSelect;

--- a/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-group-select/leavitt-person-group-select-playground.ts
@@ -17,8 +17,8 @@ import { LeavittPersonGroupSelect } from '@leavittsoftware/web/leavitt/person-gr
 @customElement('leavitt-person-group-select-playground')
 export class LeavittPersonGroupSelectPlaygroundElement extends LitElement {
   @state() apiService: ApiService;
-  @queryAll('leavitt-person-group-select)') protected inputs!: NodeListOf<LeavittPersonGroupSelect>;
-  @query('leavitt-person-group-select[methods-demo]') protected methodsSelect!: LeavittPersonGroupSelect;
+  @queryAll('leavitt-person-group-select)') protected accessor inputs!: NodeListOf<LeavittPersonGroupSelect>;
+  @query('leavitt-person-group-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonGroupSelect;
 
   constructor() {
     super();

--- a/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-demo.ts
@@ -11,7 +11,7 @@ import './leavitt-person-select-playground';
 
 @customElement('leavitt-person-select-demo')
 export class LeavittPersonSelectDemoElement extends LitElement {
-  @state() refreshToken: string | null = null;
+  @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
 

--- a/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-demo.ts
@@ -10,7 +10,7 @@ import '../../shared/smart-demo';
 import './leavitt-person-select-playground';
 
 @customElement('leavitt-person-select-demo')
-export class LeavittPersonSelectDemoElement extends LitElement {
+export class LeavittPersonSelectDemo extends LitElement {
   @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
@@ -23,7 +23,7 @@ export class LeavittPersonSelectDemoElement extends LitElement {
 
   render() {
     return html`
-      <story-header name="Leavitt Person Select" packageName="leavitt-elements" className="LeavittPersonSelectElement"></story-header>
+      <story-header name="Leavitt Person Select" className="LeavittPersonSelect"></story-header>
       ${this.refreshToken
         ? html`<smart-demo
             html-file=${`index.html?#${encodeURIComponent(this.refreshToken)}`}

--- a/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-playground.ts
@@ -18,8 +18,8 @@ import { Person } from '@leavittsoftware/lg-core-typescript';
 @customElement('leavitt-person-select-playground')
 export class LeavittPersonSelectPlaygroundElement extends LitElement {
   @state() apiService: ApiService;
-  @queryAll('leavitt-person-select') protected inputs!: NodeListOf<LeavittPersonSelect>;
-  @query('leavitt-person-select[methods-demo]') protected methodsSelect!: LeavittPersonSelect;
+  @queryAll('leavitt-person-select') protected accessor inputs!: NodeListOf<LeavittPersonSelect>;
+  @query('leavitt-person-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonSelect;
 
   constructor() {
     super();

--- a/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-playground.ts
@@ -17,7 +17,7 @@ import { Person } from '@leavittsoftware/lg-core-typescript';
 /* playground-fold */
 @customElement('leavitt-person-select-playground')
 export class LeavittPersonSelectPlaygroundElement extends LitElement {
-  @state() apiService: ApiService;
+  @state() private accessor apiService: ApiService;
   @queryAll('leavitt-person-select') protected accessor inputs!: NodeListOf<LeavittPersonSelect>;
   @query('leavitt-person-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonSelect;
 

--- a/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-select/leavitt-person-select-playground.ts
@@ -16,7 +16,7 @@ import { Person } from '@leavittsoftware/lg-core-typescript';
 
 /* playground-fold */
 @customElement('leavitt-person-select-playground')
-export class LeavittPersonSelectPlaygroundElement extends LitElement {
+export class LeavittPersonSelectPlayground extends LitElement {
   @state() private accessor apiService: ApiService;
   @queryAll('leavitt-person-select') protected accessor inputs!: NodeListOf<LeavittPersonSelect>;
   @query('leavitt-person-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonSelect;

--- a/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-demo.ts
@@ -10,7 +10,7 @@ import '../../shared/smart-demo';
 import './leavitt-user-feedback-playground';
 
 @customElement('leavitt-user-feedback-demo')
-export class LeavittCompanySelectDemoElement extends LitElement {
+export class LeavittCompanySelectDemo extends LitElement {
   @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
@@ -23,7 +23,7 @@ export class LeavittCompanySelectDemoElement extends LitElement {
 
   render() {
     return html`
-      <story-header name="Leavitt Company Select" packageName="leavitt-elements" className="LeavittCompanySelectElement"></story-header>
+      <story-header name="Leavitt Company Select" className="LeavittCompanySelect"></story-header>
       ${this.refreshToken
         ? html`<smart-demo
             html-file=${`index.html?#${encodeURIComponent(this.refreshToken)}`}

--- a/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-demo.ts
@@ -11,7 +11,7 @@ import './leavitt-user-feedback-playground';
 
 @customElement('leavitt-user-feedback-demo')
 export class LeavittCompanySelectDemoElement extends LitElement {
-  @state() refreshToken: string | null = null;
+  @state() private accessor refreshToken: string | null = null;
 
   static styles = [StoryStyles, css``];
 

--- a/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-playground.ts
@@ -12,7 +12,7 @@ import { LeavittUserFeedback } from '@leavittsoftware/web/leavitt/user-feedback/
 /* playground-fold */
 @customElement('leavitt-user-feedback-playground')
 export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
-  @state() apiService: ApiService;
+  @state() private accessor apiService: ApiService;
   @query('leavitt-user-feedback[methods-demo]') protected accessor methodsSelect!: LeavittUserFeedback;
   @query('leavitt-user-feedback[duplicate-api-calls]') protected accessor duplicateAPICallsSelect!: LeavittUserFeedback;
   @queryAll('leavitt-user-feedback') protected accessor inputs!: NodeListOf<LeavittUserFeedback>;

--- a/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-playground.ts
@@ -1,8 +1,7 @@
 /* playground-fold */
 import { css, html, LitElement } from 'lit';
-import { customElement, query, queryAll, state } from 'lit/decorators.js';
+import { customElement, query, queryAll } from 'lit/decorators.js';
 import { h1, p } from '@leavittsoftware/web/titanium/styles/styles';
-import ApiService from '@leavittsoftware/web/leavitt/api-service/api-service';
 import '@leavittsoftware/web/titanium/snackbar/snackbar';
 
 /* playground-fold-end */
@@ -11,8 +10,7 @@ import { LeavittUserFeedback } from '@leavittsoftware/web/leavitt/user-feedback/
 
 /* playground-fold */
 @customElement('leavitt-user-feedback-playground')
-export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
-  @state() private accessor apiService: ApiService;
+export class LeavittPersonCompanySelectPlayground extends LitElement {
   @query('leavitt-user-feedback[methods-demo]') protected accessor methodsSelect!: LeavittUserFeedback;
   @query('leavitt-user-feedback[duplicate-api-calls]') protected accessor duplicateAPICallsSelect!: LeavittUserFeedback;
   @queryAll('leavitt-user-feedback') protected accessor inputs!: NodeListOf<LeavittUserFeedback>;

--- a/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-playground.ts
+++ b/packages/leavittbook/src/demos/leavitt-user-feedback/leavitt-user-feedback-playground.ts
@@ -13,9 +13,9 @@ import { LeavittUserFeedback } from '@leavittsoftware/web/leavitt/user-feedback/
 @customElement('leavitt-user-feedback-playground')
 export class LeavittPersonCompanySelectPlaygroundElement extends LitElement {
   @state() apiService: ApiService;
-  @query('leavitt-user-feedback[methods-demo]') protected methodsSelect!: LeavittUserFeedback;
-  @query('leavitt-user-feedback[duplicate-api-calls]') protected duplicateAPICallsSelect!: LeavittUserFeedback;
-  @queryAll('leavitt-user-feedback') protected inputs!: NodeListOf<LeavittUserFeedback>;
+  @query('leavitt-user-feedback[methods-demo]') protected accessor methodsSelect!: LeavittUserFeedback;
+  @query('leavitt-user-feedback[duplicate-api-calls]') protected accessor duplicateAPICallsSelect!: LeavittUserFeedback;
+  @queryAll('leavitt-user-feedback') protected accessor inputs!: NodeListOf<LeavittUserFeedback>;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/profile-picture-menu/profile-picture-menu-demo.ts
+++ b/packages/leavittbook/src/demos/profile-picture-menu/profile-picture-menu-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './profile-picture-menu-playground';
 
 @customElement('profile-picture-menu-demo')
-export class ProfilePictureMenuDemoElement extends LitElement {
+export class ProfilePictureMenuDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Profile picture menu" packageName="profile-picture" className="ProfilePictureMenuElement"></story-header>
+      <story-header name="Profile picture menu" className="ProfilePictureMenu"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/profile-picture-menu/project.json"
         ><profile-picture-menu-playground></profile-picture-menu-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/profile-picture/profile-picture-demo.ts
+++ b/packages/leavittbook/src/demos/profile-picture/profile-picture-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './profile-picture-playground';
 
 @customElement('profile-picture-demo')
-export class ProfilePictureDemoElement extends LitElement {
+export class ProfilePictureDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Profile picture" packageName="profile-picture" className="ProfilePictureElement"></story-header>
+      <story-header name="Profile picture" className="ProfilePicture"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/profile-picture/project.json"
         ><profile-picture-playground></profile-picture-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-access-denied-page/titanium-access-denied-page-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-access-denied-page/titanium-access-denied-page-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-access-denied-page-playground';
 
 @customElement('titanium-access-denied-page-demo')
-export class TitaniumAccessDeniedDemoElement extends LitElement {
+export class TitaniumAccessDeniedDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium access denied page" packageName="titanium-access-denied-page" className="TitaniumAccessDeniedPageElement"></story-header>
+      <story-header name="Titanium access denied page" className="TitaniumAccessDeniedPage"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-access-denied-page/project.json"
         ><titanium-access-denied-page-playground></titanium-access-denied-page-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-address-input/titanium-address-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-address-input/titanium-address-input-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-address-input-playground';
 
 @customElement('titanium-address-input-demo')
-export class TitaniumAddressInputDemoElement extends LitElement {
+export class TitaniumAddressInputDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Address Input" packageName="titanium-address-input" className="TitaniumAddressInputElement"></story-header>
+      <story-header name="Titanium Address Input" className="TitaniumAddressInput"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-address-input/project.json"
         ><titanium-address-input-playground></titanium-address-input-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-address-input/titanium-address-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-address-input/titanium-address-input-playground.ts
@@ -19,8 +19,8 @@ import { GoogleAddressInput } from '@leavittsoftware/web/titanium/address-input/
 export class TitaniumAddressInputPlayground extends LitElement {
   @state() protected setLocationResult: string | null = null;
 
-  @query('google-address-input[demo-a]') protected googleAddressInputDemoA!: GoogleAddressInput;
-  @query('titanium-address-input[demo-a]') protected titaniumAddressInputDemoA!: TitaniumAddressInput;
+  @query('google-address-input[demo-a]') protected accessor googleAddressInputDemoA!: GoogleAddressInput;
+  @query('titanium-address-input[demo-a]') protected accessor titaniumAddressInputDemoA!: TitaniumAddressInput;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-address-input/titanium-address-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-address-input/titanium-address-input-playground.ts
@@ -17,7 +17,7 @@ import { GoogleAddressInput } from '@leavittsoftware/web/titanium/address-input/
 /* playground-fold */
 @customElement('titanium-address-input-playground')
 export class TitaniumAddressInputPlayground extends LitElement {
-  @state() protected setLocationResult: string | null = null;
+  @state() protected accessor setLocationResult: string | null = null;
 
   @query('google-address-input[demo-a]') protected accessor googleAddressInputDemoA!: GoogleAddressInput;
   @query('titanium-address-input[demo-a]') protected accessor titaniumAddressInputDemoA!: TitaniumAddressInput;

--- a/packages/leavittbook/src/demos/titanium-card/titanium-card-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-card/titanium-card-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-card-playground';
 
 @customElement('titanium-card-demo')
-export class TitaniumChipDemoElement extends LitElement {
+export class TitaniumChipDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium card" packageName="titanium-card" className="TitaniumCardElement"></story-header>
+      <story-header name="Titanium card" className="TitaniumCard"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-card/project.json"
         ><titanium-card-playground></titanium-card-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-chip-multi-select/titanium-chip-multi-select-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-chip-multi-select/titanium-chip-multi-select-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-chip-multi-select-playground';
 
 @customElement('titanium-chip-multi-select-demo')
-export class TitaniumChipMultiSelectDemoElement extends LitElement {
+export class TitaniumChipMultiSelectDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium chip multi-select" packageName="titanium-chip-multi-select" className="TitaniumChipMultiSelectElement"></story-header>
+      <story-header name="Titanium chip multi-select" className="TitaniumChipMultiSelect"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-chip-multi-select/project.json"
         ><titanium-chip-multi-select-playground></titanium-chip-multi-select-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-chip-multi-select/titanium-chip-multi-select-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-chip-multi-select/titanium-chip-multi-select-playground.ts
@@ -16,9 +16,9 @@ const chipLabels = ['Dog', 'Cat', 'Lion', 'Hedgehog', 'Turtle', 'Monkey', 'Owl',
 /* playground-fold */
 @customElement('titanium-chip-multi-select-playground')
 export class TitaniumChipMultiSelectPlayground extends LitElement {
-  @state() protected demoItems: string[] = chipLabels.slice(0, 4);
-  @state() protected disabled: boolean = false;
-  @state() protected supportingText: string | null = 'Service animals are welcome.';
+  @state() protected accessor demoItems: string[] = chipLabels.slice(0, 4);
+  @state() protected accessor disabled: boolean = false;
+  @state() protected accessor supportingText: string | null = 'Service animals are welcome.';
   @query('titanium-chip-multi-select[demo2]') private accessor titaniumChipMultiSelect: TitaniumChipMultiSelect;
 
   static styles = [

--- a/packages/leavittbook/src/demos/titanium-chip-multi-select/titanium-chip-multi-select-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-chip-multi-select/titanium-chip-multi-select-playground.ts
@@ -19,7 +19,7 @@ export class TitaniumChipMultiSelectPlayground extends LitElement {
   @state() protected demoItems: string[] = chipLabels.slice(0, 4);
   @state() protected disabled: boolean = false;
   @state() protected supportingText: string | null = 'Service animals are welcome.';
-  @query('titanium-chip-multi-select[demo2]') titaniumChipMultiSelect: TitaniumChipMultiSelect;
+  @query('titanium-chip-multi-select[demo2]') private accessor titaniumChipMultiSelect: TitaniumChipMultiSelect;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-confirm-dialog/titanium-confirm-dialog-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-confirm-dialog/titanium-confirm-dialog-demo.ts
@@ -14,7 +14,7 @@ export class TitaniumConfirmDialogDemo extends LitElement {
 
   render() {
     return html`
-      <story-header name="Titanium confirm dialog" packageName="titanium-confirm-dialog" className="TitaniumConfirmDialog"></story-header>
+      <story-header name="Titanium confirm dialog" className="TitaniumConfirmDialog"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-confirm-dialog/project.json"
         ><titanium-confirm-dialog-playground></titanium-confirm-dialog-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-confirm-dialog/titanium-confirm-dialog-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-confirm-dialog/titanium-confirm-dialog-playground.ts
@@ -12,7 +12,7 @@ import { ConfirmDialogOpenEvent } from '@leavittsoftware/web/titanium/confirm-di
 /* playground-fold */
 @customElement('titanium-confirm-dialog-playground')
 export class TitaniumConfirmDialogPlayground extends LitElement {
-  @state() private confirmed = false;
+  @state() private accessor confirmed = false;
 
   async #open() {
     const confirmationDialogEvent = new ConfirmDialogOpenEvent(

--- a/packages/leavittbook/src/demos/titanium-data-table-header/titanium-data-table-header-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table-header/titanium-data-table-header-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-data-table-header-playground';
 
 @customElement('titanium-data-table-header-demo')
-export class TitaniumDataTableHeaderDemoElement extends LitElement {
+export class TitaniumDataTableHeaderDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium data table header" packageName="titanium-data-table" className="TitaniumDataTableHeaderElement"></story-header>
+      <story-header name="Titanium data table header" className="TitaniumDataTableHeader"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-data-table-header/project.json"
         ><titanium-data-table-header-playground></titanium-data-table-header-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-data-table-item/titanium-data-table-item-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table-item/titanium-data-table-item-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-data-table-item-playground';
 
 @customElement('titanium-data-table-item-demo')
-export class TitaniumDataTableItemDemoElement extends LitElement {
+export class TitaniumDataTableItemDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium data table item" packageName="titanium-data-table" className="TitaniumDataTableItemElement"></story-header>
+      <story-header name="Titanium data table item" className="TitaniumDataTableItem"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-data-table-item/project.json"
         ><titanium-data-table-item-playground></titanium-data-table-item-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-data-table-item/titanium-data-table-item-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table-item/titanium-data-table-item-playground.ts
@@ -11,7 +11,7 @@ import { TitaniumDataTableItem } from '@leavittsoftware/web/titanium/data-table/
 /* playground-fold */
 @customElement('titanium-data-table-item-playground')
 export class TitaniumDataTableItemPlayground extends LitElement {
-  @query('titanium-data-table-item[select-demo]') protected selectItem!: TitaniumDataTableItem;
+  @query('titanium-data-table-item[select-demo]') protected accessor selectItem!: TitaniumDataTableItem;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-data-table/draggable.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table/draggable.ts
@@ -15,7 +15,7 @@ import '@leavittsoftware/web/titanium/data-table/data-table';
 type Car = { Name: string; Appearance: 'plaid' | 'ugly' | 'slick' };
 @customElement('draggable-playground')
 export class DraggablePlayground extends LitElement {
-  @state() protected draggableItems: Array<Partial<Car>> = [];
+  @state() protected accessor draggableItems: Array<Partial<Car>> = [];
 
   firstUpdated() {
     this.draggableItems = [

--- a/packages/leavittbook/src/demos/titanium-data-table/full-working-example.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table/full-working-example.ts
@@ -52,18 +52,18 @@ const allTeslas: Array<Car> = [
 
 @customElement('titanium-data-table-full-playground')
 export class TitaniumDataTableFullPlayground extends LitElement {
-  @state() protected allItems: Array<Partial<Car>> = [];
-  @state() protected items: Array<Partial<Car>> = [];
-  @state() protected selected: Array<Partial<Car>> = [];
-  @state() protected searchTerm: string = '';
-  @state() protected resultTotal: number = 0;
-  @state() protected sortDirection: '' | 'asc' | 'desc' = 'asc';
-  @state() protected sortBy: string = 'Name';
-  @state() protected filterController: FilterController<FilterKeys>;
+  @state() protected accessor allItems: Array<Partial<Car>> = [];
+  @state() protected accessor items: Array<Partial<Car>> = [];
+  @state() protected accessor selected: Array<Partial<Car>> = [];
+  @state() protected accessor searchTerm: string = '';
+  @state() protected accessor resultTotal: number = 0;
+  @state() protected accessor sortDirection: '' | 'asc' | 'desc' = 'asc';
+  @state() protected accessor sortBy: string = 'Name';
+  @state() protected accessor filterController: FilterController<FilterKeys>;
 
-  @state() protected singleSelect: boolean = false;
-  @state() protected disableSelect: boolean = false;
-  @state() protected disablePaging: boolean = false;
+  @state() protected accessor singleSelect: boolean = false;
+  @state() protected accessor disableSelect: boolean = false;
+  @state() protected accessor disablePaging: boolean = false;
 
   @query('titanium-data-table') protected accessor dataTable!: TitaniumDataTable;
   @query('data-table-demo-filter-modal') protected accessor filterModal!: DataTableDemoFilterModalElement;

--- a/packages/leavittbook/src/demos/titanium-data-table/full-working-example.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table/full-working-example.ts
@@ -65,8 +65,8 @@ export class TitaniumDataTableFullPlayground extends LitElement {
   @state() protected disableSelect: boolean = false;
   @state() protected disablePaging: boolean = false;
 
-  @query('titanium-data-table') protected dataTable!: TitaniumDataTable;
-  @query('data-table-demo-filter-modal') protected filterModal!: DataTableDemoFilterModalElement;
+  @query('titanium-data-table') protected accessor dataTable!: TitaniumDataTable;
+  @query('data-table-demo-filter-modal') protected accessor filterModal!: DataTableDemoFilterModalElement;
 
   constructor() {
     super();

--- a/packages/leavittbook/src/demos/titanium-data-table/full-working-example.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table/full-working-example.ts
@@ -66,7 +66,7 @@ export class TitaniumDataTableFullPlayground extends LitElement {
   @state() protected accessor disablePaging: boolean = false;
 
   @query('titanium-data-table') protected accessor dataTable!: TitaniumDataTable;
-  @query('data-table-demo-filter-modal') protected accessor filterModal!: DataTableDemoFilterModalElement;
+  @query('data-table-demo-filter-modal') protected accessor filterModal!: DataTableDemoFilterModal;
 
   constructor() {
     super();
@@ -353,7 +353,7 @@ export class TitaniumDataTableFullPlayground extends LitElement {
 }
 
 @customElement('data-table-demo-filter-modal')
-export class DataTableDemoFilterModalElement extends LitElement {
+export class DataTableDemoFilterModal extends LitElement {
   @state() protected accessor filterController: FilterController<FilterKeys>;
   @state() protected accessor appearance: string;
 

--- a/packages/leavittbook/src/demos/titanium-data-table/titanium-data-table-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table/titanium-data-table-demo.ts
@@ -10,12 +10,12 @@ import './draggable';
 import './full-working-example';
 
 @customElement('titanium-data-table-demo')
-export class TitaniumDataTableDemoElement extends LitElement {
+export class TitaniumDataTableDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium data table" packageName="titanium-data-table" className="TitaniumDataTableElement"></story-header>
+      <story-header name="Titanium data table" className="TitaniumDataTable"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-data-table/project.json">
         <titanium-data-table-full-playground></titanium-data-table-full-playground>
         <hr />

--- a/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-demo.ts
@@ -9,7 +9,7 @@ import '../../shared/smart-demo';
 import './titanium-date-input-playground';
 
 @customElement('titanium-date-input-demo')
-export class TitaniumDateInputItemDemoElement extends LitElement {
+export class TitaniumDateInputItemDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {

--- a/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-playground.ts
@@ -16,7 +16,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 @customElement('titanium-date-input-playground')
 export class TitaniumDateInputItemPlayground extends LitElement {
   @query('titanium-date-input[demo1]') protected accessor input!: TitaniumDateInput;
-  @state() value: string;
+  @state() private accessor value: string;
   static styles = [
     h1,
     p,

--- a/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-playground.ts
@@ -15,7 +15,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 /* playground-fold */
 @customElement('titanium-date-input-playground')
 export class TitaniumDateInputItemPlayground extends LitElement {
-  @query('titanium-date-input[demo1]') protected input!: TitaniumDateInput;
+  @query('titanium-date-input[demo1]') protected accessor input!: TitaniumDateInput;
   @state() value: string;
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-demo.ts
@@ -14,7 +14,7 @@ export class TitaniumDateRangeSelectorDemo extends LitElement {
 
   render() {
     return html`
-      <story-header name="Titanium date range selector" packageName="titanium-date-range-selector" className="TitaniumDateRangeSelector"></story-header>
+      <story-header name="Titanium date range selector" className="TitaniumDateRangeSelector"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-date-range-selector/project.json"
         ><titanium-date-range-selector-playground></titanium-date-range-selector-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-playground.ts
@@ -14,7 +14,7 @@ import { DateRanges } from '@leavittsoftware/web/titanium/date-range-selector/ty
 /* playground-fold */
 @customElement('titanium-date-range-selector-playground')
 export class TitaniumDateRangePlaygroundElement extends LitElement {
-  @query('titanium-date-range-selector[events]') protected eventsDemoInput!: TitaniumDateRangeSelector;
+  @query('titanium-date-range-selector[events]') protected accessor eventsDemoInput!: TitaniumDateRangeSelector;
 
   @state() protected startDate: string = '2020-01-02';
   @state() protected endDate: string = '2020-01-04';

--- a/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-playground.ts
@@ -13,7 +13,7 @@ import { DateRanges } from '@leavittsoftware/web/titanium/date-range-selector/ty
 
 /* playground-fold */
 @customElement('titanium-date-range-selector-playground')
-export class TitaniumDateRangePlaygroundElement extends LitElement {
+export class TitaniumDateRangePlayground extends LitElement {
   @query('titanium-date-range-selector[events]') protected accessor eventsDemoInput!: TitaniumDateRangeSelector;
 
   @state() protected accessor startDate: string = '2020-01-02';

--- a/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-date-range-selector/titanium-date-range-selector-playground.ts
@@ -16,9 +16,9 @@ import { DateRanges } from '@leavittsoftware/web/titanium/date-range-selector/ty
 export class TitaniumDateRangePlaygroundElement extends LitElement {
   @query('titanium-date-range-selector[events]') protected accessor eventsDemoInput!: TitaniumDateRangeSelector;
 
-  @state() protected startDate: string = '2020-01-02';
-  @state() protected endDate: string = '2020-01-04';
-  @state() eventFired: boolean = false;
+  @state() protected accessor startDate: string = '2020-01-02';
+  @state() protected accessor endDate: string = '2020-01-04';
+  @state() protected accessor eventFired: boolean = false;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-drawer/titanium-drawer-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-drawer/titanium-drawer-demo.ts
@@ -14,7 +14,7 @@ export class TitaniumDrawerDemo extends LitElement {
 
   render() {
     return html`
-      <story-header name="Titanium Drawer" packageName="titanium-drawer" className="TitaniumDrawer"></story-header>
+      <story-header name="Titanium Drawer" className="TitaniumDrawer"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-drawer/project.json"
         ><titanium-drawer-playground></titanium-drawer-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-drawer/titanium-drawer-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-drawer/titanium-drawer-playground.ts
@@ -16,8 +16,8 @@ import { TitaniumDrawer } from '@leavittsoftware/web/titanium/drawer/drawer';
 /* playground-fold */
 @customElement('titanium-drawer-playground')
 export class TitaniumDrawerPlayground extends LitElement {
-  @query('titanium-drawer[one]') drawerOne: TitaniumDrawer;
-  @query('titanium-drawer[two]') drawerTwo: TitaniumDrawer;
+  @query('titanium-drawer[one]') private accessor drawerOne: TitaniumDrawer;
+  @query('titanium-drawer[two]') private accessor drawerTwo: TitaniumDrawer;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-demo.ts
@@ -9,12 +9,12 @@ import './titanium-duration-input-playground';
 import '@api-viewer/docs';
 
 @customElement('titanium-duration-input-demo')
-export class TitaniumDurationInputDemoElement extends LitElement {
+export class TitaniumDurationInputDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Duration Input" packageName="titanium-duration-input" className="TitaniumDurationInputElement"></story-header>
+      <story-header name="Titanium Duration Input" className="TitaniumDurationInput"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-duration-input/project.json"
         ><titanium-duration-input-playground></titanium-duration-input-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -17,7 +17,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 /* playground-fold */
 @customElement('titanium-duration-input-playground')
 export class TitaniumDurationInputPlayground extends LitElement {
-  @state() duration: duration.Duration | null = dayjs.duration(14400);
+  @state() private accessor duration: duration.Duration | null = dayjs.duration(14400);
   @query('titanium-duration-input[demo]') private accessor requiredInput: TitaniumDurationInput;
 
   static styles = [

--- a/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-duration-input/titanium-duration-input-playground.ts
@@ -18,7 +18,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 @customElement('titanium-duration-input-playground')
 export class TitaniumDurationInputPlayground extends LitElement {
   @state() duration: duration.Duration | null = dayjs.duration(14400);
-  @query('titanium-duration-input[demo]') requiredInput: TitaniumDurationInput;
+  @query('titanium-duration-input[demo]') private accessor requiredInput: TitaniumDurationInput;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-error-page/titanium-error-page-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-error-page/titanium-error-page-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-error-page-playground';
 
 @customElement('titanium-error-page-demo')
-export class TitaniumErrorDemoElement extends LitElement {
+export class TitaniumErrorDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium error page" packageName="titanium-error-page" tagName="titanium-error-page" klass="TitaniumErrorPageElement"></story-header>
+      <story-header name="Titanium error page" tagName="titanium-error-page" klass="TitaniumErrorPageElement"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-error-page/project.json"
         ><titanium-error-page-playground></titanium-error-page-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-error-page/titanium-error-page-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-error-page/titanium-error-page-demo.ts
@@ -14,7 +14,7 @@ export class TitaniumErrorDemo extends LitElement {
 
   render() {
     return html`
-      <story-header name="Titanium error page" tagName="titanium-error-page" klass="TitaniumErrorPageElement"></story-header>
+      <story-header name="Titanium error page" className="TitaniumErrorPage"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-error-page/project.json"
         ><titanium-error-page-playground></titanium-error-page-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-full-page-loading-indicator/titanium-full-page-loading-indicator-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-full-page-loading-indicator/titanium-full-page-loading-indicator-demo.ts
@@ -9,16 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-full-page-loading-indicator-playground';
 
 @customElement('titanium-full-page-loading-indicator-demo')
-export class TitaniumFullPageLoadingIndicatorDemoElement extends LitElement {
+export class TitaniumFullPageLoadingIndicatorDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header
-        name="Titanium full page loading indicator"
-        packageName="titanium-loading-indicator"
-        className="TitaniumFullPageLoadingIndicatorElement"
-      ></story-header>
+      <story-header name="Titanium full page loading indicator" className="TitaniumFullPageLoadingIndicator"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-full-page-loading-indicator/project.json"
         ><titanium-full-page-loading-indicator-playground></titanium-full-page-loading-indicator-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-header/titanium-header-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-header/titanium-header-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-header-playground';
 
 @customElement('titanium-header-demo')
-export class TitaniumHeaderItemDemoElement extends LitElement {
+export class TitaniumHeaderItemDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Header" packageName="titanium-header" className="TitaniumHeaderItemElement"></story-header>
+      <story-header name="Titanium Header" className="TitaniumHeaderItem"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-header/project.json"
         ><titanium-header-playground></titanium-header-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-icon-picker/titanium-icon-picker-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-icon-picker/titanium-icon-picker-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-icon-picker-playground';
 
 @customElement('titanium-icon-picker-demo')
-export class TitaniumIconPickerDemoElement extends LitElement {
+export class TitaniumIconPickerDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium icon picker" packageName="titanium-icon-picker" className="TitaniumIconPicker"></story-header>
+      <story-header name="Titanium icon picker" className="TitaniumIconPicker"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-icon-picker/project.json"
         ><titanium-icon-picker-playground></titanium-icon-picker-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-icon-picker/titanium-icon-picker-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-icon-picker/titanium-icon-picker-playground.ts
@@ -12,7 +12,7 @@ import { TitaniumIconPicker } from '@leavittsoftware/web/titanium/icon-picker/ic
 /* playground-fold */
 @customElement('titanium-icon-picker-playground')
 export class TitaniumIconPickerPlayground extends LitElement {
-  @query('titanium-icon-picker[demo2]') requiredInput: TitaniumIconPicker;
+  @query('titanium-icon-picker[demo2]') private accessor requiredInput: TitaniumIconPicker;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-input-validator/titanium-input-validator-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-input-validator/titanium-input-validator-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-input-validator-playground';
 
 @customElement('titanium-input-validator-demo')
-export class TitaniumInputValidatorDemoElement extends LitElement {
+export class TitaniumInputValidatorDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Input Validator" packageName="titanium-input-validator" className="TitaniumInputValidatorElement"></story-header>
+      <story-header name="Titanium Input Validator" className="TitaniumInputValidator"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-input-validator/project.json"
         ><titanium-input-validator-playground></titanium-input-validator-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-input-validator/titanium-input-validator-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-input-validator/titanium-input-validator-playground.ts
@@ -15,7 +15,7 @@ import { formStyles } from '../../styles/form-styles';
 /* playground-fold */
 @customElement('titanium-input-validator-playground')
 export class TitaniumInputValidatorPlayground extends LitElement {
-  @state() iconSelected = '';
+  @state() private accessor iconSelected = '';
   @queryAll('titanium-input-validator') private accessor validators: NodeListOf<TitaniumInputValidator>;
 
   static styles = [

--- a/packages/leavittbook/src/demos/titanium-input-validator/titanium-input-validator-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-input-validator/titanium-input-validator-playground.ts
@@ -16,7 +16,7 @@ import { formStyles } from '../../styles/form-styles';
 @customElement('titanium-input-validator-playground')
 export class TitaniumInputValidatorPlayground extends LitElement {
   @state() iconSelected = '';
-  @queryAll('titanium-input-validator') validators: NodeListOf<TitaniumInputValidator>;
+  @queryAll('titanium-input-validator') private accessor validators: NodeListOf<TitaniumInputValidator>;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-page-control/titanium-page-control-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-page-control/titanium-page-control-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-page-control-playground';
 
 @customElement('titanium-page-control-demo')
-export class TitaniumPageControlDemoElement extends LitElement {
+export class TitaniumPageControlDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Page Control" packageName="titanium-data-table" className="TitaniumPageControlElement"></story-header>
+      <story-header name="Titanium Page Control" className="TitaniumPageControl"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-page-control/project.json"
         ><titanium-page-control-playground></titanium-page-control-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-page-control/titanium-page-control-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-page-control/titanium-page-control-playground.ts
@@ -11,7 +11,7 @@ import { TitaniumPageControl } from '@leavittsoftware/web/titanium/data-table/pa
 /* playground-fold */
 @customElement('titanium-page-control-playground')
 export class TitaniumPageControlPlayground extends LitElement {
-  @query('titanium-page-control[main]') pageControl: TitaniumPageControl;
+  @query('titanium-page-control[main]') private accessor pageControl: TitaniumPageControl;
   @state() protected count: number = 25;
   @state() protected data;
   @state() protected filteredData;

--- a/packages/leavittbook/src/demos/titanium-page-control/titanium-page-control-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-page-control/titanium-page-control-playground.ts
@@ -12,9 +12,9 @@ import { TitaniumPageControl } from '@leavittsoftware/web/titanium/data-table/pa
 @customElement('titanium-page-control-playground')
 export class TitaniumPageControlPlayground extends LitElement {
   @query('titanium-page-control[main]') private accessor pageControl: TitaniumPageControl;
-  @state() protected count: number = 25;
-  @state() protected data;
-  @state() protected filteredData;
+  @state() protected accessor count: number = 25;
+  @state() protected accessor data;
+  @state() protected accessor filteredData;
 
   firstUpdated() {
     this.data = Array(25)

--- a/packages/leavittbook/src/demos/titanium-search-input/titanium-search-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-search-input/titanium-search-input-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-search-input-playground';
 
 @customElement('titanium-search-input-demo')
-export class TitaniumSearchInputItemDemoElement extends LitElement {
+export class TitaniumSearchInputItemDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Search Input" packageName="titanium-search-input" className="TitaniumSearchInputItemElement"></story-header>
+      <story-header name="Titanium Search Input" className="TitaniumSearchInputItem"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-search-input/project.json"
         ><titanium-search-input-playground></titanium-search-input-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-search-input/titanium-search-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-search-input/titanium-search-input-playground.ts
@@ -15,7 +15,7 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 /* playground-fold */
 @customElement('titanium-search-input-playground')
 export class TitaniumSearchInputItemPlayground extends LitElement {
-  @query('titanium-search-input[method-focused]') protected methodFocus!: TitaniumSearchInput;
+  @query('titanium-search-input[method-focused]') protected accessor methodFocus!: TitaniumSearchInput;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-show-hide-playground';
 
 @customElement('titanium-show-hide-demo')
-export class TitaniumShowHideDemoElement extends LitElement {
+export class TitaniumShowHideDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium show hide" packageName="titanium-show-hide" className="TitaniumShowHideElement"></story-header>
+      <story-header name="Titanium show hide" className="TitaniumShowHide"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-show-hide/project.json"
         ><titanium-show-hide-playground></titanium-show-hide-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-show-hide/titanium-show-hide-playground.ts
@@ -13,9 +13,9 @@ import dayjs from 'dayjs/esm';
 @customElement('titanium-show-hide-playground')
 export class TitaniumColorInputPlayground extends LitElement {
   @query('titanium-show-hide[required]') requiredInput;
-  @state() protected verticalStepValue = 10;
-  @state() protected horizontalStepValue = 3;
-  @state() protected collapsed;
+  @state() protected accessor verticalStepValue = 10;
+  @state() protected accessor horizontalStepValue = 3;
+  @state() protected accessor collapsed;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-smart-attachment-input/titanium-smart-attachment-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-smart-attachment-input/titanium-smart-attachment-input-demo.ts
@@ -9,16 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-smart-attachment-input-playground';
 
 @customElement('titanium-smart-attachment-input-demo')
-export class TitaniumSmartAttachmentInputDemoElement extends LitElement {
+export class TitaniumSmartAttachmentInputDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header
-        name="Titanium Smart Attachment Input"
-        packageName="titanium-smart-attachment-input"
-        className="TitaniumSmartAttachmentInputElement"
-      ></story-header>
+      <story-header name="Titanium Smart Attachment Input" className="TitaniumSmartAttachmentInput"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-smart-attachment-input/project.json"
         ><titanium-smart-attachment-input-playground></titanium-smart-attachment-input-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-smart-attachment-input/titanium-smart-attachment-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-smart-attachment-input/titanium-smart-attachment-input-playground.ts
@@ -13,10 +13,10 @@ import { TitaniumSmartAttachmentInput } from '@leavittsoftware/web/titanium/smar
 export class TitaniumSmartAttachmentInputPlayground extends LitElement {
   @state() protected getFilesResult: string | null = null;
   @state() protected hasChanges: boolean = false;
-  @query('titanium-smart-attachment-input[get-files]') protected getFilesInput!: TitaniumSmartAttachmentInput;
-  @query('titanium-smart-attachment-input[preselect]') protected preselectFilesInput!: TitaniumSmartAttachmentInput;
-  @query('titanium-smart-attachment-input[preselect-disabled]') protected preselectDisabledFilesInput!: TitaniumSmartAttachmentInput;
-  @query('titanium-smart-attachment-input[reset]') protected resetInput!: TitaniumSmartAttachmentInput;
+  @query('titanium-smart-attachment-input[get-files]') protected accessor getFilesInput!: TitaniumSmartAttachmentInput;
+  @query('titanium-smart-attachment-input[preselect]') protected accessor preselectFilesInput!: TitaniumSmartAttachmentInput;
+  @query('titanium-smart-attachment-input[preselect-disabled]') protected accessor preselectDisabledFilesInput!: TitaniumSmartAttachmentInput;
+  @query('titanium-smart-attachment-input[reset]') protected accessor resetInput!: TitaniumSmartAttachmentInput;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/demos/titanium-snackbar/titanium-snackbar-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-snackbar/titanium-snackbar-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-snackbar-playground';
 
 @customElement('titanium-snackbar-demo')
-export class TitaniumSnackbarDemoElement extends LitElement {
+export class TitaniumSnackbarDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Snackbar" packageName="titanium-snackbar" className="TitaniumSnackbarElement"></story-header>
+      <story-header name="Titanium Snackbar" className="TitaniumSnackbar"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-snackbar/project.json"
         ><titanium-snackbar-playground></titanium-snackbar-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-styles/titanium-styles-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-styles/titanium-styles-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-styles-playground';
 
 @customElement('titanium-styles-demo')
-export class TitaniumStylesDemoElement extends LitElement {
+export class TitaniumStylesDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium styles" packageName="titanium-styles"></story-header>
+      <story-header name="Titanium styles"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-styles/project.json"
         ><titanium-styles-playground></titanium-styles-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-toolbar/titanium-toolbar-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-toolbar/titanium-toolbar-demo.ts
@@ -14,7 +14,7 @@ export class TitaniumToolbarDemo extends LitElement {
 
   render() {
     return html`
-      <story-header name="Titanium toolbar" tagName="titanium-toolbar" className="TitaniumToolbar"></story-header>
+      <story-header name="Titanium toolbar" className="TitaniumToolbar"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-toolbar/project.json"
         ><titanium-toolbar-playground></titanium-toolbar-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-toolbar/titanium-toolbar-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-toolbar/titanium-toolbar-demo.ts
@@ -9,12 +9,12 @@ import '../../shared/smart-demo';
 import './titanium-toolbar-playground';
 
 @customElement('titanium-toolbar-demo')
-export class TitaniumToolbarDemoElement extends LitElement {
+export class TitaniumToolbarDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium toolbar" packageName="titanium-toolbar" tagName="titanium-toolbar" className="TitaniumToolbarElement"></story-header>
+      <story-header name="Titanium toolbar" tagName="titanium-toolbar" className="TitaniumToolbar"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-toolbar/project.json"
         ><titanium-toolbar-playground></titanium-toolbar-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-youtube-input/titanium-youtube-input-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-youtube-input/titanium-youtube-input-demo.ts
@@ -9,12 +9,12 @@ import './titanium-youtube-input-playground';
 import '@api-viewer/docs';
 
 @customElement('titanium-youtube-input-demo')
-export class TitaniumYoutubeInputDemoElement extends LitElement {
+export class TitaniumYoutubeInputDemo extends LitElement {
   static styles = [StoryStyles, css``];
 
   render() {
     return html`
-      <story-header name="Titanium Youtube Input" packageName="titanium-youtube-input" className="TitaniumYoutubeInputElement"></story-header>
+      <story-header name="Titanium Youtube Input" className="TitaniumYoutubeInput"></story-header>
       <smart-demo line-numbers resizable project-src="../src/demos/titanium-youtube-input/project.json"
         ><titanium-youtube-input-playground></titanium-youtube-input-playground>
       </smart-demo>

--- a/packages/leavittbook/src/demos/titanium-youtube-input/titanium-youtube-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-youtube-input/titanium-youtube-input-playground.ts
@@ -13,8 +13,8 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 /* playground-fold */
 @customElement('titanium-youtube-input-playground')
 export class TitaniumYoutubeInputPlayground extends LitElement {
-  @queryAll('titanium-youtube-input') protected inputs!: NodeListOf<TitaniumYouTubeInput>;
-  @query('titanium-youtube-input[required]') requiredInput: TitaniumYouTubeInput;
+  @queryAll('titanium-youtube-input') protected accessor inputs!: NodeListOf<TitaniumYouTubeInput>;
+  @query('titanium-youtube-input[required]') protected accessor requiredInput: TitaniumYouTubeInput;
 
   static styles = [
     h1,

--- a/packages/leavittbook/src/getting-started.ts
+++ b/packages/leavittbook/src/getting-started.ts
@@ -5,7 +5,7 @@ import '@leavittsoftware/web/titanium/header/header';
 import '@leavittsoftware/web/titanium/card/card';
 
 @customElement('getting-started')
-export default class GettingStartedElement extends LitElement {
+export default class GettingStarted extends LitElement {
   static styles = [
     h1,
     h2,

--- a/packages/leavittbook/src/shared/npm-stats.ts
+++ b/packages/leavittbook/src/shared/npm-stats.ts
@@ -4,10 +4,10 @@ import { CountUp } from 'countup.js';
 
 @customElement('npm-stats')
 export default class NpmStats extends LitElement {
-  @query('span.major') protected major: HTMLDivElement;
-  @query('span.minor') protected minor: HTMLDivElement;
-  @query('span.rev') protected rev: HTMLDivElement;
-  @query('span.downloads') protected downloads: HTMLDivElement;
+  @query('span.major') protected accessor major: HTMLDivElement;
+  @query('span.minor') protected accessor minor: HTMLDivElement;
+  @query('span.rev') protected accessor rev: HTMLDivElement;
+  @query('span.downloads') protected accessor downloads: HTMLDivElement;
 
   #package = '@leavittsoftware%2Fweb';
 

--- a/packages/leavittbook/src/shared/smart-demo.ts
+++ b/packages/leavittbook/src/shared/smart-demo.ts
@@ -8,11 +8,11 @@ import { SiteErrorEvent } from '../events';
 
 @customElement('smart-demo')
 export default class SmartDemoElement extends LitElement {
-  @property({ type: String }) selectedTab: 'simple' | 'playground' = 'simple';
-  @property({ type: String, attribute: 'project-src' }) projectSrc;
-  @property({ type: String, attribute: 'html-file' }) htmlFile = 'index.html';
-  @property({ type: Boolean, attribute: 'line-numbers' }) lineNumbers;
-  @property({ type: Boolean, attribute: 'line-wrapping' }) lineWrapping;
+  @property({ type: String }) accessor selectedTab: 'simple' | 'playground' = 'simple';
+  @property({ type: String, attribute: 'project-src' }) accessor projectSrc;
+  @property({ type: String, attribute: 'html-file' }) accessor htmlFile = 'index.html';
+  @property({ type: Boolean, attribute: 'line-numbers' }) accessor lineNumbers;
+  @property({ type: Boolean, attribute: 'line-wrapping' }) accessor lineWrapping;
   @property({ type: Boolean }) resizable;
 
   updated(changedProps: PropertyValues<this>) {

--- a/packages/leavittbook/src/shared/smart-demo.ts
+++ b/packages/leavittbook/src/shared/smart-demo.ts
@@ -7,7 +7,7 @@ import '@material/web/icon/icon';
 import { SiteErrorEvent } from '../events';
 
 @customElement('smart-demo')
-export default class SmartDemoElement extends LitElement {
+export default class SmartDemo extends LitElement {
   @property({ type: String }) accessor selectedTab: 'simple' | 'playground' = 'simple';
   @property({ type: String, attribute: 'project-src' }) accessor projectSrc;
   @property({ type: String, attribute: 'html-file' }) accessor htmlFile = 'index.html';

--- a/packages/leavittbook/src/shared/story-header.ts
+++ b/packages/leavittbook/src/shared/story-header.ts
@@ -11,45 +11,47 @@ type CustomElementDeclaration = {
   kind?: string;
 };
 
-@customElement('story-header')
-export default class StoryHeaderElement extends LitElement {
-  @property({ type: String }) accessor name: string;
-  @property({ type: String }) accessor packageName: string;
-  @property({ type: String }) accessor className: string;
-  @property({ type: String }) accessor deprecatedReason: string;
+let customElementsJSON: { modules: [{ declarations: Array<CustomElementDeclaration> }] } | null = null;
 
-  @state()
-  private accessor customElementsJSON: { modules: [{ declarations: Array<CustomElementDeclaration> }] } | null = null;
-
-  @state()
-  private accessor customElementDeclaration: CustomElementDeclaration | null = null;
-
-  async firstUpdated() {
-    this.customElementsJSON = await this.#readCustomElementsJson('/custom-elements.json');
+const getCustomElementsJSON = async () => {
+  if (!Boolean(customElementsJSON)) {
+    customElementsJSON = await readCustomElementsJson('/custom-elements.json');
   }
 
+  return customElementsJSON;
+};
+
+const readCustomElementsJson = async (path: string) => {
+  try {
+    const response = await fetch(path, {
+      method: 'GET',
+    });
+    const text = await response.text();
+    return text.length ? JSON.parse(text) : {};
+  } catch (error) {
+    console.warn(error);
+  }
+  return null;
+};
+
+@customElement('story-header')
+export default class StoryHeader extends LitElement {
+  @property({ type: String }) accessor name: string;
+  @property({ type: String }) accessor className: string;
+  @property({ type: String }) accessor deprecatedReason: string;
+  @state() private accessor customElementDeclaration: CustomElementDeclaration | null = null;
+
+  @state() private accessor customElementsJSON: { modules: [{ declarations: Array<CustomElementDeclaration> }] } | null = null;
+
   async updated(changedProps: PropertyValues<this>) {
-    if ((changedProps.has('className') || changedProps.has('customElementsJSON')) && this.className && this.customElementsJSON) {
+    if (changedProps.has('className') && this.className) {
+      this.customElementsJSON = await getCustomElementsJSON();
       this.customElementDeclaration = this.customElementsJSON?.modules.flatMap((o) => o.declarations).find((o) => o.name === this.className) ?? null;
     }
   }
 
-  async #readCustomElementsJson(path: string) {
-    try {
-      const response = await fetch(path, {
-        method: 'GET',
-      });
-      const text = await response.text();
-      return text.length ? JSON.parse(text) : {};
-    } catch (error) {
-      console.warn(error);
-    }
-    return null;
-  }
-
   static styles = [
     h1,
-
     p,
     css`
       :host {
@@ -57,14 +59,9 @@ export default class StoryHeaderElement extends LitElement {
         padding-bottom: 48px;
       }
 
-      h1 {
-        padding: 0;
-        margin: 0;
-      }
-
       [code] {
         font-family: Consolas, monospace;
-        font-size: 18px;
+        font-size: 16px;
       }
 
       p[desc] {
@@ -81,7 +78,6 @@ export default class StoryHeaderElement extends LitElement {
 
       info-container {
         display: flex;
-        align-items: center;
         gap: 6px;
       }
 
@@ -91,16 +87,10 @@ export default class StoryHeaderElement extends LitElement {
         gap: 6px;
       }
 
-      [tertiary] {
-        background-color: var(--md-sys-color-tertiary);
-        color: var(--md-sys-color-on-tertiary);
-      }
-
-      info-chip {
-        height: 24px;
-        padding: 0px 6px;
-        border: 1px var(--md-sys-color-outline-variant) solid;
-        border-radius: 12px;
+      @media (max-width: 1150px) {
+        info-container {
+          flex-direction: column;
+        }
       }
     `,
   ];
@@ -108,16 +98,11 @@ export default class StoryHeaderElement extends LitElement {
     return html`
       <h1>${this.name}</h1>
       <info-container>
-        ${
-          this.customElementDeclaration?.tagName
-            ? html`<p code>${'<'}${this.customElementDeclaration?.tagName}${'>'}</p>
-                <p>|</p>`
-            : ''
-        }
         <p code>${this.className}</p>
+        ${this.customElementDeclaration?.tagName ? html`<p code>${'<'}${this.customElementDeclaration?.tagName}${'>'}</p>` : ''}
       </info-container>
       <p desc>${this.customElementDeclaration?.description}</p>
-      
+      <chip-container>
         ${this.deprecatedReason ? html`<md-suggestion-chip disabled label="Deprecated (${this.deprecatedReason})"></md-suggestion-chip>` : nothing}
       </chip-container>
     `;

--- a/packages/leavittbook/src/shared/story-header.ts
+++ b/packages/leavittbook/src/shared/story-header.ts
@@ -19,10 +19,10 @@ export default class StoryHeaderElement extends LitElement {
   @property({ type: String }) deprecatedReason: string;
 
   @state()
-  customElementsJSON: { modules: [{ declarations: Array<CustomElementDeclaration> }] } | null = null;
+  private accessor customElementsJSON: { modules: [{ declarations: Array<CustomElementDeclaration> }] } | null = null;
 
   @state()
-  customElementDeclaration: CustomElementDeclaration | null = null;
+  private accessor customElementDeclaration: CustomElementDeclaration | null = null;
 
   async firstUpdated() {
     this.customElementsJSON = await this.#readCustomElementsJson('/custom-elements.json');

--- a/packages/leavittbook/src/shared/story-header.ts
+++ b/packages/leavittbook/src/shared/story-header.ts
@@ -13,10 +13,10 @@ type CustomElementDeclaration = {
 
 @customElement('story-header')
 export default class StoryHeaderElement extends LitElement {
-  @property({ type: String }) name: string;
-  @property({ type: String }) packageName: string;
-  @property({ type: String }) className: string;
-  @property({ type: String }) deprecatedReason: string;
+  @property({ type: String }) accessor name: string;
+  @property({ type: String }) accessor packageName: string;
+  @property({ type: String }) accessor className: string;
+  @property({ type: String }) accessor deprecatedReason: string;
 
   @state()
   private accessor customElementsJSON: { modules: [{ declarations: Array<CustomElementDeclaration> }] } | null = null;

--- a/packages/web/leavitt/person-company-select/person-company-select.ts
+++ b/packages/web/leavitt/person-company-select/person-company-select.ts
@@ -42,7 +42,7 @@ export class LeavittPersonCompanySelect extends TitaniumSingleSelectBase<Partial
   /**
    *  Required
    */
-  @property({ attribute: false }) apiService: ApiService;
+  @property({ attribute: false }) accessor apiService: ApiService;
 
   #doSearchDebouncer = new Debouncer((searchTerm: string) => this.#doSearch(searchTerm));
   #abortController: AbortController = new AbortController();

--- a/packages/web/leavitt/person-group-select/person-group-select.ts
+++ b/packages/web/leavitt/person-group-select/person-group-select.ts
@@ -43,7 +43,7 @@ export class LeavittPersonGroupSelect extends TitaniumSingleSelectBase<Partial<P
   /**
    *  Required
    */
-  @property({ attribute: false }) apiService: ApiService;
+  @property({ attribute: false }) accessor apiService: ApiService;
 
   #doSearchDebouncer = new Debouncer((searchTerm: string) => this.#doSearch(searchTerm));
   #abortController: AbortController = new AbortController();

--- a/packages/web/leavitt/person-select/person-select.ts
+++ b/packages/web/leavitt/person-select/person-select.ts
@@ -33,12 +33,12 @@ export class LeavittPersonSelect extends TitaniumSingleSelectBase<Partial<Person
   /**
    *  Required
    */
-  @property({ attribute: false }) apiService: ApiService;
+  @property({ attribute: false }) accessor apiService: ApiService;
 
   /**
    *  Odata parts for the Person API call
    */
-  @property({ type: Array }) odataParts: Array<string> = [
+  @property({ type: Array }) accessor odataParts: Array<string> = [
     'top=15',
     'orderby=FullName',
     'select=FullName,CompanyName,Id,ProfilePictureCdnFileName',

--- a/packages/web/leavitt/profile-picture/profile-picture-menu.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture-menu.ts
@@ -21,29 +21,29 @@ export class ProfilePictureMenuElement extends LitElement {
   /**
    * Size in pixels of profile picture button
    */
-  @property({ type: Number }) size: number = 40;
+  @property({ type: Number }) accessor size: number = 40;
 
-  @property({ type: String }) profilePictureFileName: string | null;
+  @property({ type: String }) accessor profilePictureFileName: string | null;
 
   /**
    * Person id of user
    */
-  @property({ type: Number }) personId: number = 0;
+  @property({ type: Number }) accessor personId: number = 0;
 
   /**
    * Email address of user
    */
-  @property({ type: String }) email: string = '';
+  @property({ type: String }) accessor email: string = '';
 
   /**
    * Company of user
    */
-  @property({ type: String }) company: string = '';
+  @property({ type: String }) accessor company: string = '';
 
   /**
    * Full name of user
    */
-  @property({ type: String }) name: string = '';
+  @property({ type: String }) accessor name: string = '';
 
   @query('md-menu') private accessor menu: MdMenu;
 

--- a/packages/web/leavitt/profile-picture/profile-picture-menu.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture-menu.ts
@@ -45,7 +45,7 @@ export class ProfilePictureMenuElement extends LitElement {
    */
   @property({ type: String }) name: string = '';
 
-  @query('md-menu') private menu: MdMenu;
+  @query('md-menu') private accessor menu: MdMenu;
 
   firstUpdated() {
     GetUserManagerInstance().addEventListener(UserManagerUpdatedEvent.eventName, () => this.setUserProps());

--- a/packages/web/leavitt/profile-picture/profile-picture-menu.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture-menu.ts
@@ -17,7 +17,7 @@ import { MdMenu } from '@material/web/menu/menu';
  *
  */
 @customElement('profile-picture-menu')
-export class ProfilePictureMenuElement extends LitElement {
+export class ProfilePictureMenu extends LitElement {
   /**
    * Size in pixels of profile picture button
    */

--- a/packages/web/leavitt/profile-picture/profile-picture.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture.ts
@@ -9,7 +9,7 @@ import { customElement, property } from 'lit/decorators.js';
  *
  */
 @customElement('profile-picture')
-export class ProfilePictureElement extends LitElement {
+export class ProfilePicture extends LitElement {
   /**
    * File name of the profile picture on CDN, no extension
    */

--- a/packages/web/leavitt/profile-picture/profile-picture.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture.ts
@@ -13,32 +13,32 @@ export class ProfilePictureElement extends LitElement {
   /**
    * File name of the profile picture on CDN, no extension
    */
-  @property({ reflect: true, type: String }) fileName: string | null;
+  @property({ reflect: true, type: String }) accessor fileName: string | null;
 
   /**
    * Shape of profile picture
    */
-  @property({ reflect: true, type: String }) shape: 'circle' | 'square' = 'circle';
+  @property({ reflect: true, type: String }) accessor shape: 'circle' | 'square' = 'circle';
 
   /**
    * Shows a colored ring around the picture
    */
-  @property({ reflect: true, type: Boolean, attribute: 'show-ring' }) showRing: boolean;
+  @property({ reflect: true, type: Boolean, attribute: 'show-ring' }) accessor showRing: boolean;
 
   /**
    * Makes the image a link to the respective profile page
    */
-  @property({ reflect: true, type: Number, attribute: 'profile-picture-link-person-id' }) profilePictureLinkPersonId: number | null;
+  @property({ reflect: true, type: Number, attribute: 'profile-picture-link-person-id' }) accessor profilePictureLinkPersonId: number | null;
 
   /**
    * Size in pixels of profile picture
    */
-  @property({ type: Number }) size: number = 120;
+  @property({ type: Number }) accessor size: number = 120;
 
   /**
    *  Setting true will cause the size attribute to only determine what size image to fetch from CDN and not set any CSS size styles on the image. Therefore the image will be displayed at its intrinsic size unless further overridden by the consumer.
    */
-  @property({ type: Boolean }) useIntrinsicImageSize: boolean = false;
+  @property({ type: Boolean }) accessor useIntrinsicImageSize: boolean = false;
 
   #availableSizes = new Set([32, 64, 128, 256, 512, 1024]);
 

--- a/packages/web/leavitt/user-manager/user-manager.ts
+++ b/packages/web/leavitt/user-manager/user-manager.ts
@@ -19,39 +19,39 @@ export const GetUserManagerInstance = () => {
 
 @customElement('user-manager')
 export class UserManager extends LitElement {
-  @property({ type: Array }) roles: Array<string> = [];
+  @property({ type: Array }) accessor roles: Array<string> = [];
 
-  @property({ type: String }) fullname: string;
+  @property({ type: String }) accessor fullname: string;
 
-  @property({ type: String }) username: string;
+  @property({ type: String }) accessor username: string;
 
-  @property({ type: String }) firstName: string;
+  @property({ type: String }) accessor firstName: string;
 
-  @property({ type: String }) lastName: string;
+  @property({ type: String }) accessor lastName: string;
 
-  @property({ type: String }) company: string;
+  @property({ type: String }) accessor company: string;
 
-  @property({ type: Number }) companyId: number | null;
+  @property({ type: Number }) accessor companyId: number | null;
 
-  @property({ type: String }) profilePictureFileName: string | null;
+  @property({ type: String }) accessor profilePictureFileName: string | null;
 
-  @property({ type: String }) email: string;
+  @property({ type: String }) accessor email: string;
 
-  @property({ type: Number }) personId: number = 0;
+  @property({ type: Number }) accessor personId: number = 0;
 
-  @property({ type: Number }) refreshTokenId: number = 0;
+  @property({ type: Number }) accessor refreshTokenId: number = 0;
 
-  @property({ type: String }) redirectUrl: string = 'https://signin.leavitt.com/';
+  @property({ type: String }) accessor redirectUrl: string = 'https://signin.leavitt.com/';
 
-  @property({ type: String }) redirectDevUrl: string = 'https://devsignin.leavitt.com/';
+  @property({ type: String }) accessor redirectDevUrl: string = 'https://devsignin.leavitt.com/';
 
-  @property({ type: String }) tokenUri: string = isDevelopment ? 'https://devoauth2.leavitt.com/token' : 'https://oauth2.leavitt.com/token';
+  @property({ type: String }) accessor tokenUri: string = isDevelopment ? 'https://devoauth2.leavitt.com/token' : 'https://oauth2.leavitt.com/token';
 
-  @property({ type: String }) issuerIdentifier: string = 'https://oauth2.leavitt.com/';
+  @property({ type: String }) accessor issuerIdentifier: string = 'https://oauth2.leavitt.com/';
 
-  @property({ type: Boolean }) disableAutoload: boolean;
+  @property({ type: Boolean }) accessor disableAutoload: boolean;
 
-  @property({ type: Boolean }) isActiveEmployee: boolean;
+  @property({ type: Boolean }) accessor isActiveEmployee: boolean;
 
   #isAuthenticating: boolean;
 

--- a/packages/web/titanium/access-denied-page/access-denied-page.ts
+++ b/packages/web/titanium/access-denied-page/access-denied-page.ts
@@ -12,7 +12,7 @@ export class TitaniumAccessDeniedPage extends LitElement {
   /**
    * Reason text for the denial of access
    */
-  @property({ type: String }) message: string = 'You do not have permission to access this application.';
+  @property({ type: String }) accessor message: string = 'You do not have permission to access this application.';
 
   static styles = css`
     :host {

--- a/packages/web/titanium/address-input/address-input.ts
+++ b/packages/web/titanium/address-input/address-input.ts
@@ -29,7 +29,7 @@ export class TitaniumAddressInput extends GoogleAddressInput {
    */
   @property({ type: Boolean, attribute: 'show-county' }) accessor showCounty: boolean = false;
 
-  @query('manual-address-dialog') manualAddressDialog: ManualAddressDialog;
+  @query('manual-address-dialog') private accessor manualAddressDialog: ManualAddressDialog;
 
   static styles = [
     ...GoogleAddressInput.styles,

--- a/packages/web/titanium/address-input/manual-address-dialog.ts
+++ b/packages/web/titanium/address-input/manual-address-dialog.ts
@@ -18,9 +18,9 @@ import { reportValidityIfError } from '../hacks/report-validity-if-error';
 export class ManualAddressDialog extends LitElement {
   @query('md-dialog') protected accessor dialog: MdDialog;
 
-  @property({ type: String }) label: string = '';
-  @property({ type: Boolean, attribute: 'show-county' }) showCounty: boolean;
-  @property({ type: Boolean, attribute: 'show-street2' }) showStreet2: boolean;
+  @property({ type: String }) accessor label: string = '';
+  @property({ type: Boolean, attribute: 'show-county' }) accessor showCounty: boolean;
+  @property({ type: Boolean, attribute: 'show-street2' }) accessor showStreet2: boolean;
 
   @state() protected accessor street: string = '';
   @state() protected accessor street2: string = '';

--- a/packages/web/titanium/address-input/manual-address-dialog.ts
+++ b/packages/web/titanium/address-input/manual-address-dialog.ts
@@ -22,12 +22,12 @@ export class ManualAddressDialog extends LitElement {
   @property({ type: Boolean, attribute: 'show-county' }) showCounty: boolean;
   @property({ type: Boolean, attribute: 'show-street2' }) showStreet2: boolean;
 
-  @state() protected street: string = '';
-  @state() protected street2: string = '';
-  @state() protected city: string = '';
-  @state() protected county: string = '';
-  @state() protected state: string = '';
-  @state() protected zip: string = '';
+  @state() protected accessor street: string = '';
+  @state() protected accessor street2: string = '';
+  @state() protected accessor city: string = '';
+  @state() protected accessor county: string = '';
+  @state() protected accessor state: string = '';
+  @state() protected accessor zip: string = '';
 
   @queryAll('md-outlined-text-field, md-outlined-select') protected accessor allInputs: NodeListOf<MdOutlinedTextField | MdOutlinedSelect>;
 

--- a/packages/web/titanium/address-input/manual-address-dialog.ts
+++ b/packages/web/titanium/address-input/manual-address-dialog.ts
@@ -16,7 +16,7 @@ import { reportValidityIfError } from '../hacks/report-validity-if-error';
 
 @customElement('manual-address-dialog')
 export class ManualAddressDialog extends LitElement {
-  @query('md-dialog') protected dialog: MdDialog;
+  @query('md-dialog') protected accessor dialog: MdDialog;
 
   @property({ type: String }) label: string = '';
   @property({ type: Boolean, attribute: 'show-county' }) showCounty: boolean;
@@ -29,7 +29,7 @@ export class ManualAddressDialog extends LitElement {
   @state() protected state: string = '';
   @state() protected zip: string = '';
 
-  @queryAll('md-outlined-text-field, md-outlined-select') protected allInputs: NodeListOf<MdOutlinedTextField | MdOutlinedSelect>;
+  @queryAll('md-outlined-text-field, md-outlined-select') protected accessor allInputs: NodeListOf<MdOutlinedTextField | MdOutlinedSelect>;
 
   resolve: (value: Partial<AddressInputAddress> | null) => void;
 

--- a/packages/web/titanium/card/card.ts
+++ b/packages/web/titanium/card/card.ts
@@ -16,11 +16,11 @@ import { property, customElement } from 'lit/decorators.js';
  */
 @customElement('titanium-card')
 export class TitaniumCard extends LitElement {
-  @property({ type: Boolean, reflect: true, attribute: 'has-menu' }) hasMenu: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'has-image' }) hasImage: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'has-footer' }) hasFooter: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'filled' }) filled: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'elevated' }) elevated: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'has-menu' }) accessor hasMenu: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'has-image' }) accessor hasImage: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'has-footer' }) accessor hasFooter: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'filled' }) accessor filled: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'elevated' }) accessor elevated: boolean;
 
   static styles = [
     css`

--- a/packages/web/titanium/chip-multi-select/chip-multi-select.ts
+++ b/packages/web/titanium/chip-multi-select/chip-multi-select.ts
@@ -19,47 +19,47 @@ export class TitaniumChipMultiSelect extends LitElement {
   /**
    *  Label of input to display to users
    */
-  @property({ type: String }) label: string;
+  @property({ type: String }) accessor label: string;
 
   /**
    *  Text to show when there are no items
    */
-  @property({ type: String }) noItemsText: string = 'No items';
+  @property({ type: String }) accessor noItemsText: string = 'No items';
 
   /**
    *  Adds the * to the label
    */
-  @property({ type: Boolean }) required: boolean = false;
+  @property({ type: Boolean }) accessor required: boolean = false;
 
   /**
    *  Indicates whether or not to show the no items text
    */
-  @property({ type: Boolean }) hasItems: boolean;
+  @property({ type: Boolean }) accessor hasItems: boolean;
 
   /**
    *   Passes the supportingText property to the input-validator
    */
-  @property({ type: String }) supportingText: string;
+  @property({ type: String }) accessor supportingText: string;
 
   /**
    *  Passes the error property to the input-validator
    */
-  @property({ type: Boolean }) error: boolean;
+  @property({ type: Boolean }) accessor error: boolean;
 
   /**
    *  Passes the errorText property to the input-validator
    */
-  @property({ type: String }) errorText: string;
+  @property({ type: String }) accessor errorText: string;
 
   /**
    *  Passes the resizable property to the input-validator
    */
-  @property({ type: Boolean }) resizable: boolean;
+  @property({ type: Boolean }) accessor resizable: boolean;
 
   /**
    *  Whether or not the input should appear disabled (chips, buttons and anything else slotted will still have to be disabled individually).
    */
-  @property({ type: Boolean, reflect: true }) disabled: boolean;
+  @property({ type: Boolean, reflect: true }) accessor disabled: boolean;
 
   @query('titanium-input-validator') private accessor validator: TitaniumInputValidator;
 

--- a/packages/web/titanium/chip-multi-select/chip-multi-select.ts
+++ b/packages/web/titanium/chip-multi-select/chip-multi-select.ts
@@ -61,7 +61,7 @@ export class TitaniumChipMultiSelect extends LitElement {
    */
   @property({ type: Boolean, reflect: true }) disabled: boolean;
 
-  @query('titanium-input-validator') validator: TitaniumInputValidator;
+  @query('titanium-input-validator') private accessor validator: TitaniumInputValidator;
 
   updated(changedProps: PropertyValues<this>) {
     if ((changedProps.get('hasItems') && changedProps.has('hasItems')) || (this.hasItems && changedProps.has('hasItems'))) {

--- a/packages/web/titanium/data-table/data-table-header.ts
+++ b/packages/web/titanium/data-table/data-table-header.ts
@@ -18,62 +18,62 @@ export class TitaniumDataTableHeader extends LitElement {
   /**
    * This displayed header name
    */
-  @property({ type: String }) title: string;
+  @property({ type: String }) accessor title: string;
 
   /**
    * The column name of the currently applied sort
    */
-  @property({ type: String }) sortBy: string;
+  @property({ type: String }) accessor sortBy: string;
 
   /**
    * Optional fixed width of header in px  ex. "140px"
    */
-  @property({ reflect: true, type: String }) width: string;
+  @property({ reflect: true, type: String }) accessor width: string;
 
   /**
    * True if header is currently the sorted column. Read-only, do not set.
    */
-  @property({ type: Boolean, reflect: true }) active: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor active: boolean = false;
 
   /**
    * Current sort direction on header.
    */
-  @property({ type: String, reflect: true, attribute: 'sort-direction' }) sortDirection: 'asc' | 'desc' | '';
+  @property({ type: String, reflect: true, attribute: 'sort-direction' }) accessor sortDirection: 'asc' | 'desc' | '';
 
   /**
    * Name of header column passed along in sort-by-changed event.  Typically the name of the col in the backing DB. ex. first_name
    */
-  @property({ type: String, attribute: 'column-name' }) columnName: string;
+  @property({ type: String, attribute: 'column-name' }) accessor columnName: string;
 
   /**
    * Justify header text center
    */
-  @property({ type: Boolean, reflect: true }) center: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor center: boolean = false;
 
   /**
    * Justify header text right; moves sort icon to left.
    */
-  @property({ type: Boolean, reflect: true }) right: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor right: boolean = false;
 
   /**
    * Removes the sort icon
    */
-  @property({ type: Boolean, reflect: true, attribute: 'no-sort' }) noSort: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'no-sort' }) accessor noSort: boolean = false;
 
   /**
    * Set flex 5 on header, default is 3.
    */
-  @property({ type: Boolean, reflect: true }) large: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor large: boolean = false;
 
   /**
    * Only show this header when width is larger
    */
-  @property({ type: Boolean, reflect: true }) desktop: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor desktop: boolean = false;
 
   /**
    *  Sets if view port is small
    */
-  @property({ type: Boolean, reflect: true }) narrow: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor narrow: boolean = false;
 
   updated(changedProps) {
     if (changedProps.has('sortBy') && changedProps.get('sortBy') !== this.sortBy) {

--- a/packages/web/titanium/data-table/data-table-item.ts
+++ b/packages/web/titanium/data-table/data-table-item.ts
@@ -66,9 +66,9 @@ export class TitaniumDataTableItem extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'dragged' }) protected dragged: boolean;
   @property({ type: Boolean, reflect: true, attribute: 'dragging' }) protected dragging: boolean;
 
-  @state() protected nudgeHeight: number;
-  @state() protected hoverIndex: number | null = null;
-  @state() protected originIndex: number | null = null;
+  @state() protected accessor nudgeHeight: number;
+  @state() protected accessor hoverIndex: number | null = null;
+  @state() protected accessor originIndex: number | null = null;
 
   protected mouseEvent = (e) => this.#startItemDrag(e, 'mouse');
   protected touchEvent = (e) => {

--- a/packages/web/titanium/data-table/data-table-item.ts
+++ b/packages/web/titanium/data-table/data-table-item.ts
@@ -1,5 +1,5 @@
 import { css, html, LitElement, PropertyValues } from 'lit';
-import { property, customElement, query, state } from 'lit/decorators.js';
+import { property, customElement, state } from 'lit/decorators.js';
 import { TitaniumDataTable } from './data-table';
 
 import '@material/web/checkbox/checkbox';

--- a/packages/web/titanium/data-table/data-table-item.ts
+++ b/packages/web/titanium/data-table/data-table-item.ts
@@ -34,22 +34,22 @@ export class TitaniumDataTableItem extends LitElement {
   /**
    * The backing object that is displayed in this row.  Sent in navigate and selected events.
    */
-  @property({ type: Object }) item: unknown;
+  @property({ type: Object }) accessor item: unknown;
 
   /**
    * True when row is selected.
    */
-  @property({ reflect: true, type: Boolean }) selected: boolean = false;
+  @property({ reflect: true, type: Boolean }) accessor selected: boolean = false;
 
   /**
    *  Disables ability to select this row.
    */
-  @property({ type: Boolean, attribute: 'disable-select' }) disableSelect: boolean;
+  @property({ type: Boolean, attribute: 'disable-select' }) accessor disableSelect: boolean;
 
   /**
    *  Sets if view port is small
    */
-  @property({ type: Boolean, reflect: true }) narrow: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor narrow: boolean = false;
 
   /**
    *  Set to true to make item draggable.  When items are dropped, the items in the list's array are sorted accordingly.
@@ -59,12 +59,12 @@ export class TitaniumDataTableItem extends LitElement {
    *  <titanium-data-table @titanium-data-table-items-reorder=${() => this.requestUpdate('items')} ... >
    *
    */
-  @property({ type: Boolean, reflect: true, attribute: 'enable-dragging' }) enableDrag: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'enable-dragging' }) accessor enableDrag: boolean = false;
 
-  @property({ type: Boolean, reflect: true, attribute: 'nudge-down' }) protected nudgeDown: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'nudge-up' }) protected nudgeUp: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'dragged' }) protected dragged: boolean;
-  @property({ type: Boolean, reflect: true, attribute: 'dragging' }) protected dragging: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'nudge-down' }) protected accessor nudgeDown: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'nudge-up' }) protected accessor nudgeUp: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'dragged' }) protected accessor dragged: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'dragging' }) protected accessor dragging: boolean;
 
   @state() protected accessor nudgeHeight: number;
   @state() protected accessor hoverIndex: number | null = null;

--- a/packages/web/titanium/data-table/data-table-item.ts
+++ b/packages/web/titanium/data-table/data-table-item.ts
@@ -70,8 +70,6 @@ export class TitaniumDataTableItem extends LitElement {
   @state() protected hoverIndex: number | null = null;
   @state() protected originIndex: number | null = null;
 
-  @query('item-content') itemContent: HTMLDivElement;
-
   protected mouseEvent = (e) => this.#startItemDrag(e, 'mouse');
   protected touchEvent = (e) => {
     this.#startItemDrag(e, 'touch');

--- a/packages/web/titanium/data-table/data-table.ts
+++ b/packages/web/titanium/data-table/data-table.ts
@@ -101,12 +101,12 @@ export class TitaniumDataTable extends LitElement {
   /**
    * @ignore
    */
-  @query('slot[name="items"]') itemsSlot: HTMLSlotElement;
-  @query('slot[name="table-headers"]') protected tableHeaders: HTMLSlotElement;
+  @query('slot[name="items"]') accessor itemsSlot: HTMLSlotElement;
+  @query('slot[name="table-headers"]') protected accessor tableHeaders: HTMLSlotElement;
   /**
    * @ignore
    */
-  @query('div[items-slot]') itemsContainer: HTMLDivElement;
+  @query('div[items-slot]') accessor itemsContainer: HTMLDivElement;
 
   /**
    *  Sets if view port is small
@@ -116,11 +116,11 @@ export class TitaniumDataTable extends LitElement {
   /**
    * @ignore
    */
-  @query('md-checkbox') checkbox: MdCheckbox;
+  @query('md-checkbox') accessor checkbox: MdCheckbox;
   /**
    * @ignore
    */
-  @queryAsync('titanium-page-control') pageControl: Promise<TitaniumPageControl | null>;
+  @queryAsync('titanium-page-control') accessor pageControl: Promise<TitaniumPageControl | null>;
   #openCount = 0;
 
   /**

--- a/packages/web/titanium/data-table/data-table.ts
+++ b/packages/web/titanium/data-table/data-table.ts
@@ -41,62 +41,62 @@ export class TitaniumDataTable extends LitElement {
   /**
    * Table heading / title
    */
-  @property({ type: String }) header: string;
+  @property({ type: String }) accessor header: string;
 
   /**
    * Local storage key. Not required if header is static and unique
    */
-  @property({ type: String }) localStorageKey: string;
+  @property({ type: String }) accessor localStorageKey: string;
 
   /**
    * Available page sizes
    */
-  @property({ type: Array }) pageSizes: Array<number> = [10, 15, 20, 50];
+  @property({ type: Array }) accessor pageSizes: Array<number> = [10, 15, 20, 50];
 
   /**
    * The default page size before the user changes it
    */
-  @property({ type: Number, attribute: 'default-page-size' }) defaultPageSize: number = 10;
+  @property({ type: Number, attribute: 'default-page-size' }) accessor defaultPageSize: number = 10;
 
   /**
    * Total number of items in all pages.
    */
-  @property({ type: Number }) count: number;
+  @property({ type: Number }) accessor count: number;
 
   /**
    * Current items displayed on the table.
    */
-  @property({ type: Array }) items: Array<unknown> = [];
+  @property({ type: Array }) accessor items: Array<unknown> = [];
 
   /**
    * Current search term shown in the no result state if no results are found
    */
-  @property({ type: String }) searchTerm: string;
+  @property({ type: String }) accessor searchTerm: string;
 
   /**
    * Limits table selection mode to single-select.  Default is multi-select.
    */
-  @property({ type: Boolean, attribute: 'single-select', reflect: true }) singleSelect: boolean;
+  @property({ type: Boolean, attribute: 'single-select', reflect: true }) accessor singleSelect: boolean;
 
   /**
    * Disables all item selection on the data-table.
    */
-  @property({ type: Boolean, attribute: 'disable-select' }) disableSelect: boolean = false;
+  @property({ type: Boolean, attribute: 'disable-select' }) accessor disableSelect: boolean = false;
 
   /**
    * Disables paging.
    */
-  @property({ type: Boolean, attribute: 'disable-paging', reflect: true }) disablePaging: boolean = false;
+  @property({ type: Boolean, attribute: 'disable-paging', reflect: true }) accessor disablePaging: boolean = false;
 
   /**
    * Array of currently selected data table objects
    */
-  @property({ type: Array }) selected: Array<unknown> = [];
+  @property({ type: Array }) accessor selected: Array<unknown> = [];
 
   /**
    * When set to true, the loading state is shown.
    */
-  @property({ type: Boolean }) protected isLoading: boolean;
+  @property({ type: Boolean }) protected accessor isLoading: boolean;
 
   /**
    * @ignore
@@ -111,7 +111,7 @@ export class TitaniumDataTable extends LitElement {
   /**
    *  Sets if view port is small
    */
-  @property({ type: Boolean, reflect: true, attribute: 'narrow' }) protected narrow: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'narrow' }) protected accessor narrow: boolean = false;
 
   /**
    * @ignore

--- a/packages/web/titanium/data-table/page-control.ts
+++ b/packages/web/titanium/data-table/page-control.ts
@@ -52,7 +52,7 @@ export class TitaniumPageControl extends LitElement {
    * Disables the page control select and page navigation buttons when true
    */
   @property({ type: Boolean }) disabled: boolean;
-  @queryAsync('md-select') protected select: MdOutlinedSelect;
+  @queryAsync('md-select') protected accessor select: MdOutlinedSelect;
 
   /**
    * Gets or sets take value and assigns it to local storage.

--- a/packages/web/titanium/data-table/page-control.ts
+++ b/packages/web/titanium/data-table/page-control.ts
@@ -21,44 +21,44 @@ export class TitaniumPageControl extends LitElement {
   /**
    * Available page sizes
    */
-  @property({ type: Array }) pageSizes: Array<number> = [10, 15, 20, 50];
+  @property({ type: Array }) accessor pageSizes: Array<number> = [10, 15, 20, 50];
 
   /**
    * The default page size before the user changes it
    */
-  @property({ type: Number, attribute: 'default-page-size' }) defaultPageSize: number = 10;
+  @property({ type: Number, attribute: 'default-page-size' }) accessor defaultPageSize: number = 10;
 
   /**
    * Current page of data the table is on
    */
-  @property({ type: Number }) page: number = 0;
+  @property({ type: Number }) accessor page: number = 0;
 
   /**
    * Total number of items in all pages.
    */
-  @property({ type: Number }) count: number;
+  @property({ type: Number }) accessor count: number;
 
   /**
    * Local storage key to save the current page size.
    */
-  @property({ type: String }) localStorageKey: string;
+  @property({ type: String }) accessor localStorageKey: string;
 
   /**
    * Label for the page control. If not provided, defaults to 'Items per page'.
    */
-  @property({ type: String }) label: string = 'Items per page';
+  @property({ type: String }) accessor label: string = 'Items per page';
 
   /**
    * Disables the page control select and page navigation buttons when true
    */
-  @property({ type: Boolean }) disabled: boolean;
+  @property({ type: Boolean }) accessor disabled: boolean;
   @queryAsync('md-select') protected accessor select: MdOutlinedSelect;
 
   /**
    * Gets or sets take value and assigns it to local storage.
    */
-  @property({ type: Number })
-  get take() {
+  @property({ type: Number }) accessor take: number;
+  get() {
     const take = Number(window.localStorage.getItem(this.localStorageKey)) || 0;
     if (take > 0) {
       return take;
@@ -68,7 +68,7 @@ export class TitaniumPageControl extends LitElement {
     return defaultTake;
   }
 
-  set take(val: number) {
+  set(val: number) {
     this.page = 0;
     if (!this.pageSizes.includes(val)) {
       this.pageSizes = [...this.pageSizes, val].sort((a, b) => a - b);

--- a/packages/web/titanium/drawer/drawer.ts
+++ b/packages/web/titanium/drawer/drawer.ts
@@ -12,7 +12,7 @@ import { customElement, property, query } from 'lit/decorators.js';
  */
 @customElement('titanium-drawer')
 export class TitaniumDrawer extends LitElement {
-  @query('dialog') private dialog: HTMLDialogElement | null;
+  @query('dialog') private accessor dialog: HTMLDialogElement | null;
 
   /**
    * Set the position of content fixed when menu is closed. Only takes effect if always-show-content is set.

--- a/packages/web/titanium/drawer/drawer.ts
+++ b/packages/web/titanium/drawer/drawer.ts
@@ -17,12 +17,12 @@ export class TitaniumDrawer extends LitElement {
   /**
    * Set the position of content fixed when menu is closed. Only takes effect if always-show-content is set.
    */
-  @property({ type: Boolean, reflect: true }) fixed: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor fixed: boolean = false;
 
   /**
    * Show the slotted content regardless if the menu is open or closed
    */
-  @property({ type: Boolean, reflect: true, attribute: 'always-show-content' }) alwayShowContent: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'always-show-content' }) accessor alwayShowContent: boolean = false;
 
   async firstUpdated() {
     let touchstartX = 0;

--- a/packages/web/titanium/duration-input/duration-input.ts
+++ b/packages/web/titanium/duration-input/duration-input.ts
@@ -23,7 +23,7 @@ export class TitaniumDurationInput extends ExtendableOutlinedTextField {
    *  property of this component is actually the human readable string and not the duration you most likely
    *  want to work with. When changed a duration-change event will be dispatched.
    */
-  @property({ type: Object }) duration: duration.Duration | null = null;
+  @property({ type: Object }) accessor duration: duration.Duration | null = null;
 
   firstUpdated() {
     this.label = 'Duration';

--- a/packages/web/titanium/error-page/error-page.ts
+++ b/packages/web/titanium/error-page/error-page.ts
@@ -13,7 +13,7 @@ export class TitaniumErrorPage extends LitElement {
   /**
    * Reason text for the error
    */
-  @property({ type: String }) message: string = 'We were unable to find the page you are looking for...';
+  @property({ type: String }) accessor message: string = 'We were unable to find the page you are looking for...';
 
   static styles = css`
     :host {

--- a/packages/web/titanium/extendable-outlined-text-field/extendable-outlined-text-field.ts
+++ b/packages/web/titanium/extendable-outlined-text-field/extendable-outlined-text-field.ts
@@ -17,9 +17,9 @@ export class ExtendableOutlinedTextField extends LitElement {
    * This error state overrides the error state controlled by
    * `reportValidity()`.
    */
-  @property({ type: Boolean, reflect: true }) error = false;
+  @property({ type: Boolean, reflect: true }) accessor error = false;
 
-  @property({ type: Boolean, reflect: true }) disabled = false;
+  @property({ type: Boolean, reflect: true }) accessor disabled = false;
 
   /**
    * The error message that replaces supporting text when `error` is true. If
@@ -29,11 +29,11 @@ export class ExtendableOutlinedTextField extends LitElement {
    * This error message overrides the error message displayed by
    * `reportValidity()`.
    */
-  @property({ attribute: 'error-text' }) errorText = '';
+  @property({ attribute: 'error-text' }) accessor errorText = '';
 
-  @property() label = '';
+  @property() accessor label = '';
 
-  @property({ type: Boolean, reflect: true }) required = false;
+  @property({ type: Boolean, reflect: true }) accessor required = false;
 
   /**
    * The current value of the text field. It is always a string.
@@ -43,58 +43,58 @@ export class ExtendableOutlinedTextField extends LitElement {
   /**
    * An optional prefix to display before the input value.
    */
-  @property({ attribute: 'prefix-text' }) prefixText = '';
+  @property({ attribute: 'prefix-text' }) accessor prefixText = '';
 
   /**
    * An optional suffix to display after the input value.
    */
-  @property({ attribute: 'suffix-text' }) suffixText = '';
+  @property({ attribute: 'suffix-text' }) accessor suffixText = '';
 
   /**
    * Whether or not the text field has a leading icon. Used for SSR.
    */
   @property({ type: Boolean, attribute: 'has-leading-icon' })
-  hasLeadingIcon = false;
+  accessor hasLeadingIcon = false;
 
   /**
    * Whether or not the text field has a trailing icon. Used for SSR.
    */
   @property({ type: Boolean, attribute: 'has-trailing-icon' })
-  hasTrailingIcon = false;
+  accessor hasTrailingIcon = false;
 
   /**
    * Conveys additional information below the text field, such as how it should
    * be used.
    */
-  @property({ attribute: 'supporting-text' }) supportingText = '';
+  @property({ attribute: 'supporting-text' }) accessor supportingText = '';
 
   /**
    * Override the input text CSS `direction`. Useful for RTL languages that use
    * LTR notation for fractions.
    */
-  @property({ attribute: 'text-direction' }) textDirection = '';
+  @property({ attribute: 'text-direction' }) accessor textDirection = '';
 
   /**
    * The number of rows to display for a `type="textarea"` text field.
    * Defaults to 2.
    */
-  @property({ type: Number }) rows = 2;
+  @property({ type: Number }) accessor rows = 2;
 
   /**
    * The number of cols to display for a `type="textarea"` text field.
    * Defaults to 20.
    */
-  @property({ type: Number }) cols = 20;
+  @property({ type: Number }) accessor cols = 20;
 
   // <input> properties
-  @property({ reflect: true }) override inputMode = '';
+  @property({ reflect: true }) override accessor inputMode = '';
 
   /**
    * Defines the greatest value in the range of permitted values.
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#max
    */
-  @property() max = '';
+  @property() accessor max = '';
 
   /**
    * The maximum number of characters a user can enter into the text field. Set
@@ -102,14 +102,14 @@ export class ExtendableOutlinedTextField extends LitElement {
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#maxlength
    */
-  @property({ type: Number }) maxLength = -1;
+  @property({ type: Number }) accessor maxLength = -1;
 
   /**
    * Defines the most negative value in the range of permitted values.
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#min
    */
-  @property() min = '';
+  @property() accessor min = '';
 
   /**
    * The minimum number of characters a user can enter into the text field. Set
@@ -117,7 +117,7 @@ export class ExtendableOutlinedTextField extends LitElement {
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#minlength
    */
-  @property({ type: Number }) minLength = -1;
+  @property({ type: Number }) accessor minLength = -1;
 
   /**
    * A regular expression that the text field's value must match to pass
@@ -125,9 +125,9 @@ export class ExtendableOutlinedTextField extends LitElement {
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#pattern
    */
-  @property() pattern = '';
+  @property() accessor pattern = '';
 
-  @property({ reflect: true, converter: stringConverter }) placeholder = '';
+  @property({ reflect: true, converter: stringConverter }) accessor placeholder = '';
 
   /**
    * Indicates whether or not a user should be able to edit the text field's
@@ -135,14 +135,14 @@ export class ExtendableOutlinedTextField extends LitElement {
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#readonly
    */
-  @property({ type: Boolean, reflect: true }) readOnly = false;
+  @property({ type: Boolean, reflect: true }) accessor readOnly = false;
 
   /**
    * Indicates that input accepts multiple email addresses.
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#multiple
    */
-  @property({ type: Boolean, reflect: true }) multiple = false;
+  @property({ type: Boolean, reflect: true }) accessor multiple = false;
 
   /**
    * Returns or sets the element's step attribute, which works with min and max
@@ -150,7 +150,7 @@ export class ExtendableOutlinedTextField extends LitElement {
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#step
    */
-  @property() step = '';
+  @property() accessor step = '';
 
   /**
    * The `<input>` type to use, defaults to "text". The type greatly changes how
@@ -171,7 +171,7 @@ export class ExtendableOutlinedTextField extends LitElement {
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
    * for more details on each input type.
    */
-  @property({ reflect: true }) type: TextFieldType | UnsupportedTextFieldType = 'text';
+  @property({ reflect: true }) accessor type: TextFieldType | UnsupportedTextFieldType = 'text';
 
   /**
    * Describes what, if any, type of autocomplete functionality the input
@@ -179,7 +179,7 @@ export class ExtendableOutlinedTextField extends LitElement {
    *
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
    */
-  @property({ reflect: true }) autocomplete = '';
+  @property({ reflect: true }) accessor autocomplete = '';
 
   checkValidity() {
     return this.input.checkValidity();

--- a/packages/web/titanium/extendable-outlined-text-field/extendable-outlined-text-field.ts
+++ b/packages/web/titanium/extendable-outlined-text-field/extendable-outlined-text-field.ts
@@ -9,7 +9,7 @@ import { DOMEvent } from '../types/dom-event';
 import { redispatchEvent } from '@material/web/internal/controller/events';
 
 export class ExtendableOutlinedTextField extends LitElement {
-  @query('md-outlined-text-field') input: MdOutlinedTextField;
+  @query('md-outlined-text-field') accessor input: MdOutlinedTextField;
 
   /**
    * Gets or sets whether or not the text field is in a visually invalid state.

--- a/packages/web/titanium/header/header.ts
+++ b/packages/web/titanium/header/header.ts
@@ -20,27 +20,27 @@ export class TitaniumHeader extends LitElement {
   /**
    * Header text
    */
-  @property({ type: String }) header: string;
+  @property({ type: String }) accessor header: string;
 
   /**
    * Sub-header text
    */
-  @property({ type: String }) subHeader: string;
+  @property({ type: String }) accessor subHeader: string;
 
   /**
    * Leading header icon
    */
-  @property({ type: String }) icon: string;
+  @property({ type: String }) accessor icon: string;
 
   /**
    *  Removes the back button
    */
-  @property({ type: Boolean, reflect: true, attribute: 'no-nav' }) noNav: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'no-nav' }) accessor noNav: boolean = false;
 
   /**
    *  Lets user override back button behavior
    */
-  @property({ type: Boolean, reflect: true, attribute: 'disable-default-back-button-behavior' }) disableDefaultBackButtonBehavior: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'disable-default-back-button-behavior' }) accessor disableDefaultBackButtonBehavior: boolean = false;
 
   #handleBackClick() {
     if (this.disableDefaultBackButtonBehavior) {

--- a/packages/web/titanium/input-validator/input-validator.ts
+++ b/packages/web/titanium/input-validator/input-validator.ts
@@ -14,7 +14,7 @@ import { MdOutlinedField } from '@material/web/field/outlined-field';
 @customElement('titanium-input-validator')
 export class TitaniumInputValidator extends MdOutlinedField {
   @property({ type: Boolean }) populated: boolean = true;
-  @property({ type: Object }) evaluator: () => boolean;
+  @property({ type: Object }) accessor evaluator: () => boolean;
 
   firstUpdated() {
     this.addEventListener('focusin', () => (this.focused = true));

--- a/packages/web/titanium/search-input/search-input.ts
+++ b/packages/web/titanium/search-input/search-input.ts
@@ -19,14 +19,14 @@ export class TitaniumSearchInput extends ExtendableOutlinedTextField {
   /**
    *  Whether or not the input should hide the clear button
    */
-  @property({ type: Boolean, attribute: 'hide-clear-button' }) hideClearButton: boolean = false;
+  @property({ type: Boolean, attribute: 'hide-clear-button' }) accessor hideClearButton: boolean = false;
 
   /**
    *  Whether the input should prevent collapse.
    */
-  @property({ type: Boolean, reflect: true, attribute: 'prevent-collapse' }) preventCollapse: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'prevent-collapse' }) accessor preventCollapse: boolean = false;
 
-  @property({ type: Boolean, reflect: true, attribute: 'has-value' }) protected hasValue: boolean = true;
+  @property({ type: Boolean, reflect: true, attribute: 'has-value' }) protected accessor hasValue: boolean = true;
 
   async updated(changedProps: PropertyValues<this>) {
     if (changedProps.has('value')) {

--- a/packages/web/titanium/service-worker-notifier/service-worker-notifier.ts
+++ b/packages/web/titanium/service-worker-notifier/service-worker-notifier.ts
@@ -4,8 +4,8 @@ import { TitaniumSnackbarSingleton } from '../../titanium/snackbar/snackbar';
 
 @customElement('titanium-service-worker-notifier')
 export class TitanuimServiceWorkerNotifier extends LitElement {
-  @property({ type: String }) notificationsStatus: string;
-  @property({ type: String }) scriptUrl: string = 'service-worker.js';
+  @property({ type: String }) accessor notificationsStatus: string;
+  @property({ type: String }) accessor scriptUrl: string = 'service-worker.js';
 
   #newWorker: ServiceWorker | null;
   #refreshing = false;

--- a/packages/web/titanium/show-hide/show-hide.ts
+++ b/packages/web/titanium/show-hide/show-hide.ts
@@ -18,7 +18,7 @@ import '@material/web/button/outlined-button';
  * @cssprop [--titanium-show-hide-gap=8px] - flex direction of the for the parent of the slotted in content
  */
 @customElement('titanium-show-hide')
-export default class TitaniumShowHideElement extends LitElement {
+export default class TitaniumShowHide extends LitElement {
   /**
    * This will be the height of the content you want visible when collapsed.
    * An example would be if you have a list of items where each item is 20px in height

--- a/packages/web/titanium/show-hide/show-hide.ts
+++ b/packages/web/titanium/show-hide/show-hide.ts
@@ -24,11 +24,11 @@ export default class TitaniumShowHideElement extends LitElement {
    * An example would be if you have a list of items where each item is 20px in height
    * and you want to show only the first 2 items pass in 48px (height of 2 items + gap).
    */
-  @property({ type: Number, attribute: 'collapse-height' }) collapseHeight: number = 120;
-  @property({ type: Boolean, reflect: true, attribute: 'disable-fade' }) disableFade: boolean = false;
-  @property({ type: Boolean, reflect: true, attribute: 'collapsed' }) collapsed: boolean = true;
-  @property({ type: Boolean, reflect: true, attribute: 'has-hidden-items' }) protected hasHiddenItems: boolean = false;
-  @property({ type: Number }) hiddenItemCount: number = 0;
+  @property({ type: Number, attribute: 'collapse-height' }) accessor collapseHeight: number = 120;
+  @property({ type: Boolean, reflect: true, attribute: 'disable-fade' }) accessor disableFade: boolean = false;
+  @property({ type: Boolean, reflect: true, attribute: 'collapsed' }) accessor collapsed: boolean = true;
+  @property({ type: Boolean, reflect: true, attribute: 'has-hidden-items' }) protected accessor hasHiddenItems: boolean = false;
+  @property({ type: Number }) accessor hiddenItemCount: number = 0;
 
   @query('items-container') protected accessor itemsContainer: HTMLElement;
   @query('collapsed-box') protected accessor collapsedContainer: HTMLElement;

--- a/packages/web/titanium/show-hide/show-hide.ts
+++ b/packages/web/titanium/show-hide/show-hide.ts
@@ -30,8 +30,8 @@ export default class TitaniumShowHideElement extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'has-hidden-items' }) protected hasHiddenItems: boolean = false;
   @property({ type: Number }) hiddenItemCount: number = 0;
 
-  @query('items-container') protected itemsContainer: HTMLElement;
-  @query('collapsed-box') protected collapsedContainer: HTMLElement;
+  @query('items-container') protected accessor itemsContainer: HTMLElement;
+  @query('collapsed-box') protected accessor collapsedContainer: HTMLElement;
 
   updated(changedProps: PropertyValues<this>) {
     if (changedProps.has('collapsed')) {

--- a/packages/web/titanium/single-select-base/single-select-base.ts
+++ b/packages/web/titanium/single-select-base/single-select-base.ts
@@ -22,8 +22,8 @@ export class TitaniumSingleSelectBase<T extends Identifier> extends LoadWhile(Li
   @state() protected searchTerm: string;
   @state() protected suggestions: Array<T> = [];
 
-  @query('md-menu') protected menu: Menu | null;
-  @query('md-outlined-text-field') protected textfield: MdOutlinedTextField | null;
+  @query('md-menu') protected accessor menu: Menu | null;
+  @query('md-outlined-text-field') protected accessor textfield: MdOutlinedTextField | null;
 
   /**
    *  Sets floating label value.

--- a/packages/web/titanium/single-select-base/single-select-base.ts
+++ b/packages/web/titanium/single-select-base/single-select-base.ts
@@ -19,8 +19,8 @@ import { redispatchEvent } from '@material/web/internal/controller/events';
 
 @customElement('titanium-single-select-base')
 export class TitaniumSingleSelectBase<T extends Identifier> extends LoadWhile(LitElement) {
-  @state() protected searchTerm: string;
-  @state() protected suggestions: Array<T> = [];
+  @state() protected accessor searchTerm: string;
+  @state() protected accessor suggestions: Array<T> = [];
 
   @query('md-menu') protected accessor menu: Menu | null;
   @query('md-outlined-text-field') protected accessor textfield: MdOutlinedTextField | null;

--- a/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
+++ b/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
@@ -27,8 +27,8 @@ const LoaderGif = new URL('./images/duck-loader.gif', import.meta.url).href;
  */
 @customElement('crop-and-save-image-dialog')
 export class CropAndSaveImageDialog extends LoadWhile(LitElement) {
-  @query('md-dialog') dialog: MdDialog;
-  @query('cropper-container > img') img: HTMLImageElement;
+  @query('md-dialog') accessor dialog: MdDialog;
+  @query('cropper-container > img') accessor img: HTMLImageElement;
 
   /**
    *  Configurable CropperJs options.

--- a/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
+++ b/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
@@ -34,7 +34,7 @@ export class CropAndSaveImageDialog extends LoadWhile(LitElement) {
    *  Configurable CropperJs options.
    */
   @property({ type: Object }) options: CropperOptions = {};
-  @state() protected fileName: string = '';
+  @state() protected accessor fileName: string = '';
 
   #cropper: null | Cropper;
   #mimeType = '';

--- a/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
+++ b/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
@@ -33,7 +33,7 @@ export class CropAndSaveImageDialog extends LoadWhile(LitElement) {
   /**
    *  Configurable CropperJs options.
    */
-  @property({ type: Object }) options: CropperOptions = {};
+  @property({ type: Object }) accessor options: CropperOptions = {};
   @state() protected accessor fileName: string = '';
 
   #cropper: null | Cropper;

--- a/packages/web/titanium/smart-attachment-input/image-preview-dialog.ts
+++ b/packages/web/titanium/smart-attachment-input/image-preview-dialog.ts
@@ -20,7 +20,7 @@ export class ImagePreviewDialog extends LitElement {
   @state() protected downloadSrc: string | undefined;
   @state() protected filename: string | undefined;
 
-  @query('md-dialog') protected dialog: MdDialog;
+  @query('md-dialog') protected accessor dialog: MdDialog;
 
   async open(imageUrl: string, downloadSrc?: string, filename?: string) {
     this.imageUrl = undefined; //prevent ghost images

--- a/packages/web/titanium/smart-attachment-input/image-preview-dialog.ts
+++ b/packages/web/titanium/smart-attachment-input/image-preview-dialog.ts
@@ -16,9 +16,9 @@ import { MdDialog } from '@material/web/dialog/dialog';
  */
 @customElement('image-preview-dialog')
 export class ImagePreviewDialog extends LitElement {
-  @state() protected imageUrl: string | undefined;
-  @state() protected downloadSrc: string | undefined;
-  @state() protected filename: string | undefined;
+  @state() protected accessor imageUrl: string | undefined;
+  @state() protected accessor downloadSrc: string | undefined;
+  @state() protected accessor filename: string | undefined;
 
   @query('md-dialog') protected accessor dialog: MdDialog;
 

--- a/packages/web/titanium/smart-attachment-input/smart-attachment-input.ts
+++ b/packages/web/titanium/smart-attachment-input/smart-attachment-input.ts
@@ -36,9 +36,9 @@ export type TitaniumSmartInputOptions = Cropper.Options & { shape?: ' square' | 
  */
 @customElement('titanium-smart-attachment-input')
 export class TitaniumSmartAttachmentInput extends LitElement {
-  @property({ type: Array }) protected files: SmartAttachment[] = [];
-  @property({ type: Boolean, reflect: true, attribute: 'is-over' }) protected isOver: boolean = false;
-  @property({ type: String }) protected previewSrc: string | undefined = undefined;
+  @property({ type: Array }) protected accessor files: SmartAttachment[] = [];
+  @property({ type: Boolean, reflect: true, attribute: 'is-over' }) protected accessor isOver: boolean = false;
+  @property({ type: String }) protected accessor previewSrc: string | undefined = undefined;
 
   @query('input') protected accessor input: HTMLInputElement;
   @query('image-preview-dialog') protected accessor imagePreviewDialog!: ImagePreviewDialog;
@@ -51,67 +51,67 @@ export class TitaniumSmartAttachmentInput extends LitElement {
   /**
    *  File types to accept ex. "image/*,.pdf"
    */
-  @property({ type: String }) accept = 'image/*,.pdf';
+  @property({ type: String }) accessor accept = 'image/*,.pdf';
 
   /**
    *  Allow multiple attachments
    */
-  @property({ type: Boolean }) multiple: boolean = false;
+  @property({ type: Boolean }) accessor multiple: boolean = false;
 
   /**
    *  Requires at least one attachment on validate
    */
-  @property({ type: Boolean }) required: boolean = false;
+  @property({ type: Boolean }) accessor required: boolean = false;
 
   /**
    *  Whether or not the input should be disabled
    */
-  @property({ type: Boolean, reflect: true }) disabled: boolean = false;
+  @property({ type: Boolean, reflect: true }) accessor disabled: boolean = false;
 
   /**
    *  Requires user to confirm when delete of an attachment is requested
    */
-  @property({ type: Boolean }) confirmDelete: boolean = false;
+  @property({ type: Boolean }) accessor confirmDelete: boolean = false;
 
   /**
    *  Delete confirmation header text
    */
-  @property({ type: String }) confirmDeleteHeader: string = 'Confirm delete';
+  @property({ type: String }) accessor confirmDeleteHeader: string = 'Confirm delete';
 
   /**
    *  Delete confirmation paragraph text
    */
-  @property({ type: String }) confirmDeleteText: string = 'Are you sure you would like to delete this attachment?';
+  @property({ type: String }) accessor confirmDeleteText: string = 'Are you sure you would like to delete this attachment?';
 
   /**
    *  Add button label text
    */
-  @property({ type: String }) addButtonLabel: string = 'Add attachment';
+  @property({ type: String }) accessor addButtonLabel: string = 'Add attachment';
 
   /**
    *  Label of input
    */
-  @property({ type: String }) label: string = 'Attachments';
+  @property({ type: String }) accessor label: string = 'Attachments';
 
   /**
    *  Sets supporting text
    */
-  @property({ type: String }) supportingText: string;
+  @property({ type: String }) accessor supportingText: string;
 
   /**
    *  Text to show when there are no attachments
    */
-  @property({ type: String }) noItemsText: string = 'No attachments';
+  @property({ type: String }) accessor noItemsText: string = 'No attachments';
 
   /**
    *  Configurable CropperJs options.
    */
-  @property({ type: Object }) options: CropperOptions = {};
+  @property({ type: Object }) accessor options: CropperOptions = {};
 
   /**
    *  Image formats here are sent to the cropper
    */
-  @property({ type: Array }) croppableImageFormats: Array<string> = [
+  @property({ type: Array }) accessor croppableImageFormats: Array<string> = [
     'tiff',
     'pjp',
     'jfif',

--- a/packages/web/titanium/smart-attachment-input/smart-attachment-input.ts
+++ b/packages/web/titanium/smart-attachment-input/smart-attachment-input.ts
@@ -40,11 +40,11 @@ export class TitaniumSmartAttachmentInput extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'is-over' }) protected isOver: boolean = false;
   @property({ type: String }) protected previewSrc: string | undefined = undefined;
 
-  @query('input') protected input: HTMLInputElement;
-  @query('image-preview-dialog') protected imagePreviewDialog!: ImagePreviewDialog;
-  @query('crop-and-save-image-dialog') protected cropperDialog!: CropAndSaveImageDialog;
-  @query('md-dialog[confirm-delete]') private confirmDeleteDialog: MdDialog;
-  @query('titanium-chip-multi-select') private chipMultiSelect: TitaniumChipMultiSelect;
+  @query('input') protected accessor input: HTMLInputElement;
+  @query('image-preview-dialog') protected accessor imagePreviewDialog!: ImagePreviewDialog;
+  @query('crop-and-save-image-dialog') protected accessor cropperDialog!: CropAndSaveImageDialog;
+  @query('md-dialog[confirm-delete]') private accessor confirmDeleteDialog: MdDialog;
+  @query('titanium-chip-multi-select') private accessor chipMultiSelect: TitaniumChipMultiSelect;
 
   #originalFiles: SmartAttachment[] = [];
 

--- a/packages/web/titanium/snackbar/snackbar.ts
+++ b/packages/web/titanium/snackbar/snackbar.ts
@@ -46,28 +46,28 @@ export class TitaniumSnackbar extends LitElement implements BasicSnackBar {
   /**
    * True when opened
    */
-  @property({ type: Boolean, reflect: true }) protected opened: boolean;
+  @property({ type: Boolean, reflect: true }) protected accessor opened: boolean;
   /**
    * True when closing
    */
-  @property({ type: Boolean, reflect: true }) protected closing: boolean;
+  @property({ type: Boolean, reflect: true }) protected accessor closing: boolean;
   /**
    * True when opening
    */
-  @property({ type: Boolean, reflect: true }) protected opening: boolean;
+  @property({ type: Boolean, reflect: true }) protected accessor opening: boolean;
   /**
    * Hides the action button
    */
-  @property({ type: Boolean, reflect: true }) protected noaction: boolean;
+  @property({ type: Boolean, reflect: true }) protected accessor noaction: boolean;
 
   /**
    * Text used on the button
    */
-  @property({ type: String }) protected actionText: string;
+  @property({ type: String }) protected accessor actionText: string;
   /**
    * Message used in the snackbar.
    */
-  @property({ type: String }) protected message: string | TemplateResult;
+  @property({ type: String }) protected accessor message: string | TemplateResult;
 
   #animationTimer: number;
   #animationFrame: number;

--- a/packages/web/titanium/toolbar/toolbar.ts
+++ b/packages/web/titanium/toolbar/toolbar.ts
@@ -15,7 +15,7 @@ export class TitaniumToolbar extends LitElement {
   /**
    * Adds a box shadow around the toolbar
    */
-  @property({ type: Boolean, reflect: true }) protected shadow: boolean;
+  @property({ type: Boolean, reflect: true }) protected accessor shadow: boolean;
 
   static styles = css`
     :host {


### PR DESCRIPTION
closes #543
small refactor on story header as well. (Some tag names werent showing before because it uses className to look up the tagName in the custom elements manifest and we had renamed them to remove "Element" from the className) (Additionally we were making a fetch call to load the text of custom-elements every time for each story header. It now will be more efficient with its calls to custom-elements)
