### PR TITLE
fix(search-input): search-input not opening on click in safari

### DIFF
--- a/packages/web/titanium/search-input/search-input.ts
+++ b/packages/web/titanium/search-input/search-input.ts
@@ -74,7 +74,7 @@ export class TitaniumSearchInput extends ExtendableOutlinedTextField {
   protected override renderMainSlot() {
     return html`
       <slot></slot>
-      <md-icon-button search ?disabled=${this.disabled} @focus=${() => this.focus()} slot="leading-icon"> <md-icon search>search</md-icon></md-icon-button>
+      <md-icon-button search ?disabled=${this.disabled} @click=${() => this.focus()} @focus=${() => this.focus()} slot="leading-icon"> <md-icon search>search</md-icon></md-icon-button>
 
       ${!this.hasValue
         ? nothing

--- a/packages/web/titanium/search-input/search-input.ts
+++ b/packages/web/titanium/search-input/search-input.ts
@@ -74,7 +74,9 @@ export class TitaniumSearchInput extends ExtendableOutlinedTextField {
   protected override renderMainSlot() {
     return html`
       <slot></slot>
-      <md-icon-button search ?disabled=${this.disabled} @click=${() => this.focus()} @focus=${() => this.focus()} slot="leading-icon"> <md-icon search>search</md-icon></md-icon-button>
+      <md-icon-button search ?disabled=${this.disabled} @click=${() => this.focus()} @focus=${() => this.focus()} slot="leading-icon">
+        <md-icon search>search</md-icon></md-icon-button
+      >
 
       ${!this.hasValue
         ? nothing


### PR DESCRIPTION
clicking on the button in safari doesn't trigger a focus event. Probably an issue that should be elevated to md-components, but for now, this fixes the issue without any apparent side effects.

before

https://github.com/LeavittSoftware/apps.leavitt.com/assets/590826/a6a3dcf2-ff0a-40ad-8ac4-00f53fe91961


after

https://github.com/LeavittSoftware/apps.leavitt.com/assets/590826/8b6d6b6d-d6a5-4c0e-a702-9a06851f7525
