### PR TITLE
fix(file-explorer): notify other active file explorers when display changes

### DIFF
--- a/packages/web/leavitt/file-explorer/file-explorer.ts
+++ b/packages/web/leavitt/file-explorer/file-explorer.ts
@@ -57,6 +57,9 @@ import { ShowSnackbarEvent } from '../../titanium/snackbar/show-snackbar-event';
  */
 @customElement('leavitt-file-explorer')
 export class LeavittFileExplorer extends LoadWhile(LitElement) {
+
+  static allExplorers: LeavittFileExplorer[] = [];
+
   /**
    *  This is required.
    */
@@ -85,6 +88,7 @@ export class LeavittFileExplorer extends LoadWhile(LitElement) {
   @property({ type: String, reflect: true, attribute: 'display' })
   private set display(val: 'grid' | 'list') {
     localStorage.setItem('leavitt-file-explorer-display', val);
+    LeavittFileExplorer.allExplorers.forEach(o => o !== this ? o.requestUpdate('display') : null);
   }
 
   @property({ type: String }) private accessor state: 'no-permission' | 'files' | 'no-files' | 'error' = 'files';
@@ -106,6 +110,15 @@ export class LeavittFileExplorer extends LoadWhile(LitElement) {
   @query('titanium-confirm-dialog') private accessor confirmDialog: TitaniumConfirmDialog;
 
   #originalFolderId = 0;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    LeavittFileExplorer.allExplorers.push(this);
+  }
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    LeavittFileExplorer.allExplorers = LeavittFileExplorer.allExplorers.filter(o => o === this);
+  }
 
   firstUpdated() {
     //force attribute to reflect

--- a/packages/web/leavitt/file-explorer/file-explorer.ts
+++ b/packages/web/leavitt/file-explorer/file-explorer.ts
@@ -57,7 +57,6 @@ import { ShowSnackbarEvent } from '../../titanium/snackbar/show-snackbar-event';
  */
 @customElement('leavitt-file-explorer')
 export class LeavittFileExplorer extends LoadWhile(LitElement) {
-
   static allExplorers: LeavittFileExplorer[] = [];
 
   /**
@@ -88,7 +87,7 @@ export class LeavittFileExplorer extends LoadWhile(LitElement) {
   @property({ type: String, reflect: true, attribute: 'display' })
   private set display(val: 'grid' | 'list') {
     localStorage.setItem('leavitt-file-explorer-display', val);
-    LeavittFileExplorer.allExplorers.forEach(o => o !== this ? o.requestUpdate('display') : null);
+    LeavittFileExplorer.allExplorers.forEach((o) => (o !== this ? o.requestUpdate('display') : null));
   }
 
   @property({ type: String }) private accessor state: 'no-permission' | 'files' | 'no-files' | 'error' = 'files';
@@ -117,7 +116,7 @@ export class LeavittFileExplorer extends LoadWhile(LitElement) {
   }
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    LeavittFileExplorer.allExplorers = LeavittFileExplorer.allExplorers.filter(o => o === this);
+    LeavittFileExplorer.allExplorers = LeavittFileExplorer.allExplorers.filter((o) => o === this);
   }
 
   firstUpdated() {


### PR DESCRIPTION
Fixes issue where having multiple file explorers loaded allows the display setting to get out of sync with what's in localStorage

https://github.com/LeavittSoftware/titanium-elements/assets/590826/c00a2117-46a7-4af8-a52b-7aea20e9ef75

