### PR TITLE
fix(titanium-smart-attachment-input): Fix shape type typo

### DIFF
--- a/packages/web/titanium/smart-attachment-input/smart-attachment-input.ts
+++ b/packages/web/titanium/smart-attachment-input/smart-attachment-input.ts
@@ -24,7 +24,7 @@ import { MdDialog } from '@material/web/dialog/dialog';
 import { getCdnInlineUrl } from '../helpers/get-cdn-Inline-url';
 import { p } from '../styles/p';
 
-export type TitaniumSmartInputOptions = Cropper.Options & { shape?: ' square' | 'circle' };
+export type TitaniumSmartInputOptions = Cropper.Options & { shape?: 'square' | 'circle' };
 
 /**
  * Material outline image input with cropper


### PR DESCRIPTION
Fixes typo in the shape type option for square by removing leading space.
