### PR TITLE
feat(data-table-core): add profile-picture to image grid-area

### DIFF
--- a/packages/web/titanium/data-table/data-table-content-styles.ts
+++ b/packages/web/titanium/data-table/data-table-content-styles.ts
@@ -31,6 +31,10 @@ export const dataTableContentStyles = css`
       image-rendering: -webkit-optimize-contrast;
     }
 
+    profile-picture {
+      grid-area: image;
+    }
+
     [supporting-text] {
       grid-area: supporting-text;
     }


### PR DESCRIPTION
Tested it in the playground locally: 
<img width="1206" height="114" alt="image" src="https://github.com/user-attachments/assets/05db3692-2dc2-4eb6-8f63-8cac8cc057c8" />
