### PR TITLE
fix(date-input): remove padding breaking normal behavior

### DIFF
--- a/packages/web/titanium/date-input/date-input.ts
+++ b/packages/web/titanium/date-input/date-input.ts
@@ -357,11 +357,6 @@ export class TitaniumDateInput extends LitElement {
       md-icon-button[open-picker] {
         display: none;
       }
-
-      input {
-        padding-top: 16px;
-        padding-bottom: 16px;
-      }
     }
   `;
 


### PR DESCRIPTION
closes #676

Lines up the icon with the mm/dd/yyyy
<img width="1416" height="294" alt="no-modification" src="https://github.com/user-attachments/assets/79c21356-91b8-40f7-a532-7be24f7f929c" />

md-filled-text-field type date for reference
<img width="991" height="258" alt="md-example" src="https://github.com/user-attachments/assets/b53992e0-66af-4ddb-8d71-31a7b45eecd6" />

