### PR TITLE
fix(date-input): IOS/safari styles. Fix supporting text height issue.

### DIFF
--- a/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-date-input/titanium-date-input-playground.ts
@@ -5,6 +5,8 @@ import { h1, p } from '@leavittsoftware/web/titanium/styles/styles';
 import '@leavittsoftware/web/titanium/card/card';
 
 import '@material/web/button/outlined-button';
+import '@material/web/textfield/outlined-text-field';
+import '@material/web/textfield/filled-text-field';
 
 /* playground-fold-end */
 
@@ -16,6 +18,8 @@ import { DOMEvent } from '@leavittsoftware/web/titanium/types/dom-event';
 @customElement('titanium-date-input-playground')
 export class TitaniumDateInputItemPlayground extends LitElement {
   @query('titanium-date-input[demo1]') protected accessor input!: TitaniumDateInput;
+  @query('titanium-date-input[filled]') protected accessor filledInput!: TitaniumDateInput;
+
   @state() private accessor value: string;
   static styles = [
     h1,
@@ -28,8 +32,26 @@ export class TitaniumDateInputItemPlayground extends LitElement {
         gap: 24px;
       }
 
+      md-filled-text-field {
+        --md-filled-text-field-container-shape: 16px;
+        --md-filled-text-field-active-indicator-height: 0;
+        --md-filled-text-field-error-active-indicator-height: 0;
+        --md-filled-text-field-hover-active-indicator-height: 0;
+        --md-filled-text-field-focus-active-indicator-height: 0;
+        --md-filled-text-field-disabled-active-indicator-height: 0;
+      }
+
       titanium-card {
         gap: 24px;
+      }
+
+      two-column {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 24px;
+        align-items: start;
+        margin-top: 12px;
+        margin-bottom: 12px;
       }
 
       footer {
@@ -48,35 +70,87 @@ export class TitaniumDateInputItemPlayground extends LitElement {
         <h1>Main demo</h1>
 
         <main card-body>
-          <titanium-date-input
-            autocomplete="bday"
-            demo1
-            label="Birthday"
-            @change=${(e: DOMEvent<TitaniumDateInput>) => (this.value = e.target.value)}
-          ></titanium-date-input>
+          <two-column>
+            <titanium-date-input
+              autocomplete="bday"
+              demo1
+              label="Birthday"
+              @change=${(e: DOMEvent<TitaniumDateInput>) => (this.value = e.target.value)}
+            ></titanium-date-input>
+            <md-outlined-text-field label="Birthday" value="Test"></md-outlined-text-field>
+          </two-column>
+
+          <two-column>
+            <titanium-date-input filled label="Start date"></titanium-date-input>
+            <md-filled-text-field label="Start date" value="Test"></md-filled-text-field>
+          </two-column>
         </main>
         <span card-menu>Output: ${this.value}</span>
 
         <footer card-footer>
-          <md-outlined-button @click=${() => (this.input.value = this.input.value ? '' : '2023-12-08')}>Set an value</md-outlined-button>
+          <md-outlined-button
+            @click=${() => {
+              this.input.value = this.input.value ? '' : '2023-12-08';
+              this.filledInput.value = this.filledInput.value ? '' : '2023-12-08';
+             
+            }}
+            >Set a value</md-outlined-button
+          >
           <md-outlined-button
             @click=${() => {
               this.input.error = true;
               this.input.errorText = this.input.errorText ? '' : 'Oh no not that date!';
+              this.filledInput.error = true;
+              this.filledInput.errorText = this.filledInput.errorText ? '' : 'Oh no not that date!';
             }}
             >Set an error</md-outlined-button
           >
-          <md-outlined-button @click=${() => (this.input.required = !this.input.required)}>Toggle required</md-outlined-button>
-          <md-outlined-button @click=${() => (this.input.disabled = !this.input.disabled)}>Toggle disabled</md-outlined-button>
-
-          <md-outlined-button @click=${() => (this.input.supportingText = this.input.supportingText ? '' : 'Supporting text example')}
-            >Toggle supporting text</md-outlined-button
+          <md-outlined-button
+            @click=${() => {
+              this.input.required = !this.input.required;
+              this.filledInput.required = !this.filledInput.required;
+            }}
+            >Toggle required</md-outlined-button
+          >
+          <md-outlined-button
+            @click=${() => {
+              this.input.disabled = !this.input.disabled;
+              this.filledInput.disabled = !this.filledInput.disabled;
+            }}
+            >Toggle disabled</md-outlined-button
           >
 
-          <md-outlined-button @click=${() => (this.input.label = this.input.label ? '' : 'Start date')}>Toggle label text</md-outlined-button>
+          <md-outlined-button
+            @click=${() => {
+              this.input.supportingText = this.input.supportingText ? '' : 'Thank you for your birthday! I hope you have a great day!';
+              this.filledInput.supportingText = this.filledInput.supportingText ? '' : 'Thank you for your birthday! I hope you have a great day!';
+            }}
+          >
+            Toggle supporting text
+          </md-outlined-button>
 
-          <md-outlined-button @click=${() => this.input.reset()}>Reset</md-outlined-button>
-          <md-outlined-button @click=${() => this.input.reportValidity()}>Report validity</md-outlined-button>
+          <md-outlined-button
+            @click=${() => {
+              this.input.label = this.input.label ? '' : 'Start date';
+              this.filledInput.label = this.filledInput.label ? '' : 'Start date';
+            }}
+            >Toggle label text</md-outlined-button
+          >
+
+          <md-outlined-button
+            @click=${() => {
+              this.input.reset();
+              this.filledInput.reset();
+            }}
+            >Reset</md-outlined-button
+          >
+          <md-outlined-button
+            @click=${() => {
+              this.input.reportValidity();
+              this.filledInput.reportValidity();
+            }}
+            >Report validity</md-outlined-button
+          >
         </footer>
       </titanium-card>
 
@@ -84,13 +158,6 @@ export class TitaniumDateInputItemPlayground extends LitElement {
         <h1>Date time demo</h1>
         <div>
           <titanium-date-input type="datetime-local" label="Reboot every"></titanium-date-input>
-        </div>
-      </titanium-card>
-
-      <titanium-card>
-        <h1>Filled demo</h1>
-        <div>
-          <titanium-date-input filled label="Start date"></titanium-date-input>
         </div>
       </titanium-card>
     `;

--- a/packages/web/titanium/date-input/date-input.ts
+++ b/packages/web/titanium/date-input/date-input.ts
@@ -298,13 +298,18 @@ export class TitaniumDateInput extends LitElement {
       --md-filled-field-hover-active-indicator-height: 0;
       --md-filled-field-focus-active-indicator-height: 0;
       --md-filled-field-disabled-active-indicator-height: 0;
+
+      --md-filled-field-label-text-populated-line-height: 14px;
+    }
+
+    :host(:not([filled])) {
+      --md-outlined-field-top-space: 15px;
+      --md-outlined-field-bottom-space: 15px;
     }
 
     md-outlined-field,
     md-filled-field {
       width: 100%;
-      /* Adjust to match height of other text inputs */
-      max-height: 56px;
     }
 
     input::-webkit-calendar-picker-indicator {
@@ -324,6 +329,13 @@ export class TitaniumDateInput extends LitElement {
       padding-bottom: 7px;
     }
 
+    :host([filled]) _::-webkit-full-page-media,
+    :host([filled]) _:future,
+    :host([filled]) input {
+      padding-top: 21px;
+      padding-bottom: 0;
+    }
+
     _::-webkit-full-page-media,
     _:future,
     md-icon-button[open-picker] {
@@ -337,10 +349,15 @@ export class TitaniumDateInput extends LitElement {
       }
 
       input {
-        height: 35px;
-        padding-top: 16px;
-        padding-bottom: 6px;
         min-width: 100px;
+        padding-bottom: 10px;
+        padding-top: 16px;
+        height: 30px;
+      }
+
+      :host([filled]) input {
+        padding-bottom: 3px;
+        padding-top: 23px;
       }
     }
 
@@ -356,6 +373,15 @@ export class TitaniumDateInput extends LitElement {
 
       md-icon-button[open-picker] {
         display: none;
+      }
+
+      :host([filled]) {
+        --md-filled-field-label-text-populated-line-height: 16px;
+      }
+
+      :host(:not([filled])) {
+        --md-outlined-field-top-space: 16px;
+        --md-outlined-field-bottom-space: 16px;
       }
     }
   `;


### PR DESCRIPTION
I went throught safari/ios/firefox/chrome to make sure the date input alignment/height is working correctly. I need this height fix for edit profile page on workforce.

<img width="2436" height="1125" alt="IMG_6433" src="https://github.com/user-attachments/assets/78ce1710-0d46-4edf-a9be-b6da28c48cb3" />
