### PR TITLE
docs(icon-picker): add filled example

### DIFF
--- a/packages/leavittbook/src/demos/titanium-icon-picker/titanium-icon-picker-playground.ts
+++ b/packages/leavittbook/src/demos/titanium-icon-picker/titanium-icon-picker-playground.ts
@@ -52,7 +52,12 @@ export class TitaniumIconPickerPlayground extends LitElement {
         <titanium-icon-picker></titanium-icon-picker>
       </div>
 
-      
+      <h1>Filled</h1>
+      <p>Filled icon picker example</p>
+      <div>
+        <titanium-icon-picker filled></titanium-icon-picker>
+      </div>
+
       <h1>Favorite icons</h1>
       <p></p>
       <div>


### PR DESCRIPTION
closes #692

Apparently this one is already upgraded thanks to it's extension of single select. So i just added an example to the docs