### PR TITLE
fix(date-range-selector): add appropriately radius to prevent clipping

### DIFF
--- a/packages/web/titanium/date-range-selector/date-range-selector.ts
+++ b/packages/web/titanium/date-range-selector/date-range-selector.ts
@@ -174,6 +174,11 @@ export class TitaniumDateRangeSelector extends LitElement {
 
       gap: 12px;
       padding: 12px;
+      border-radius: 0 0 4px 4px;
+    }
+
+    :host([filled]) menu-actions {
+      border-radius: 0 0 16px 16px;
     }
 
     input-container {


### PR DESCRIPTION
Before
<img width="959" height="548" alt="image" src="https://github.com/user-attachments/assets/81b0cca6-b462-44d1-8eab-09ac75ff4ceb" />

After
<img width="1208" height="522" alt="image" src="https://github.com/user-attachments/assets/14788161-6e51-47de-91c4-818c13c7148b" />
