### PR TITLE
fix(titanium-address-input): ncurc with vers. lock for google api loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 packages/web/**/*.js
 packages/web/**/*.map
 packages/web/**/*.d.ts
+!packages/web/.ncurc.js
 packages/leavittbook/src/**/*.js
 packages/leavittbook/src/**/*.map
 packages/leavittbook/src/**/*.d.ts

--- a/packages/web/.ncurc.js
+++ b/packages/web/.ncurc.js
@@ -1,0 +1,8 @@
+const rejectAll = ['@googlemaps/js-api-loader'];
+const rejectMajor = [];
+
+module.exports = {
+  upgrade: true,
+  reject: (dependencyName) => rejectAll.includes(dependencyName),
+  target: (dependencyName) => (rejectMajor.includes(dependencyName) ? 'minor' : 'latest'),
+};


### PR DESCRIPTION
closes #700