### PR TITLE
fix(data-table): use friendly name for csv header

### DIFF
--- a/packages/leavittbook/src/demos/titanium-data-table-core-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-data-table-core-demo.ts
@@ -290,6 +290,7 @@ export class TitaniumDataTableCoreDemo extends LitElement {
         key: 'MaxSpeed',
         render: (item) => html`${item.MaxSpeed} mph`,
         width: '250px',
+        friendlyName: 'Max Speed',
       },
       {
         key: 'IsElectric',

--- a/packages/web/titanium/data-table/data-table-core.ts
+++ b/packages/web/titanium/data-table/data-table-core.ts
@@ -588,7 +588,8 @@ export class TitaniumDataTableCore<T extends object> extends LoadWhile(LitElemen
                               this.items.map((item) => {
                                 const itemData = {};
                                 for (const metaData of currentlyShownColumnMetaData) {
-                                  itemData[metaData.key] = metaData.csvValue ? metaData.csvValue(item) : item[metaData.key];
+                                  const header = metaData.friendlyName ?? metaData.key;
+                                  itemData[header] = metaData.csvValue ? metaData.csvValue(item) : item[metaData.key];
                                 }
                                 return itemData;
                               }) ?? [];


### PR DESCRIPTION
closes #708

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CSV export header generation; main risk is minor breaking/changed column names in downstream CSV consumers.
> 
> **Overview**
> Updates `titanium-data-table-core` CSV export to use each column’s `friendlyName` (falling back to `key`) as the generated CSV header, instead of always using the raw `key`.
> 
> Adjusts the core demo metadata to provide a `friendlyName` for the `MaxSpeed` column so the exported CSV header reads "Max Speed".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 152436c6a05ad04d4902527b964e75db02b12f9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->