### PR TITLE
feat(email-history-viewer/-filled): add test message column

### DIFF
--- a/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
@@ -40,6 +40,7 @@ import {
   TitaniumTextFieldSearchContext,
 } from '@leavittsoftware/web/titanium/site-search-text-field-controller/site-search-text-field-controller';
 import { Debouncer } from '@leavittsoftware/web/titanium/helpers/debouncer';
+import { isDevelopment } from '@leavittsoftware/web/titanium/helpers/is-development';
 
 import dayjs from 'dayjs/esm';
 import ApiService from '../api-service/api-service';
@@ -102,14 +103,6 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
             ${item.EmailTemplate?.IsExpired ? html`<div inactive>Inactive</div>` : ''}`,
         csvValue: (item) => item.EmailTemplate?.Name ?? '',
         width: '150px',
-      },
-      {
-        key: 'IsTestMessage',
-        friendlyName: 'Test',
-        getSortExpression: () => 'IsTestMessage',
-        render: (item) => html`<div>${item.IsTestMessage ? 'Yes' : 'No'}</div>`,
-        csvValue: (item) => (item.IsTestMessage ? 'Yes' : 'No'),
-        width: '50px',
       },
       {
         key: 'Bool1',
@@ -184,6 +177,17 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
         return this.#reload();
       },
     });
+    if (isDevelopment) {
+      const lastColumnIndex = this.tableMetaData.itemMetaData.length - 1; // place just before the preview button column
+      this.tableMetaData.itemMetaData.splice(lastColumnIndex, 0, {
+        key: 'IsTestMessage',
+        friendlyName: 'Test',
+        getSortExpression: () => 'IsTestMessage',
+        render: (item) => html`<div>${item.IsTestMessage ? 'Yes' : 'No'}</div>`,
+        csvValue: (item) => (item.IsTestMessage ? 'Yes' : 'No'),
+        width: '50px'
+      });
+    }
   }
 
   async #reload() {

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
@@ -244,7 +244,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
     filterParts = [...filterParts, ...this.filterController.getActiveFilterOdata()];
 
     const odataParts = [
-      'select=Id,Recipients,SentDate,Subject,IsTestMessage',
+      'select=Id,Recipients,SentDate,Subject'+(isDevelopment ? ',IsTestMessage' : ''),
       'expand=EmailTemplate(select=Id,Name,IsExpired)',
       `top=${this.pageControl?.take}`,
       `skip=${(this.pageControl?.take ?? 0) * (this.pageControl?.page ?? 0)}`,
@@ -257,7 +257,9 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
     if (orderby) {
       odataParts.push(`orderby=${orderby}`);
     }
-
+    if (!isDevelopment) {
+      filterParts.push('IsTestMessage eq false');
+    }
     if (filterParts.length > 0) {
       odataParts.push(`filter=${filterParts.join(' and ')}`);
     }

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
@@ -101,7 +101,15 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
           html`<div>${item.EmailTemplate?.Name}</div>
             ${item.EmailTemplate?.IsExpired ? html`<div inactive>Inactive</div>` : ''}`,
         csvValue: (item) => item.EmailTemplate?.Name ?? '',
-        width: '200px',
+        width: '150px',
+      },
+      {
+        key: 'IsTestMessage',
+        friendlyName: 'Test',
+        getSortExpression: () => 'IsTestMessage',
+        render: (item) => html`<div>${item.IsTestMessage ? 'Yes' : 'No'}</div>`,
+        csvValue: (item) => (item.IsTestMessage ? 'Yes' : 'No'),
+        width: '50px',
       },
       {
         key: 'Bool1',
@@ -232,7 +240,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
     filterParts = [...filterParts, ...this.filterController.getActiveFilterOdata()];
 
     const odataParts = [
-      'select=Id,Recipients,SentDate,Subject',
+      'select=Id,Recipients,SentDate,Subject,IsTestMessage',
       'expand=EmailTemplate(select=Id,Name,IsExpired)',
       `top=${this.pageControl?.take}`,
       `skip=${(this.pageControl?.take ?? 0) * (this.pageControl?.page ?? 0)}`,

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
@@ -244,7 +244,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
     filterParts = [...filterParts, ...this.filterController.getActiveFilterOdata()];
 
     const odataParts = [
-      'select=Id,Recipients,SentDate,Subject'+(isDevelopment ? ',IsTestMessage' : ''),
+      `select=Id,Recipients,SentDate,Subject${isDevelopment ? ',IsTestMessage' : ''}`,
       'expand=EmailTemplate(select=Id,Name,IsExpired)',
       `top=${this.pageControl?.take}`,
       `skip=${(this.pageControl?.take ?? 0) * (this.pageControl?.page ?? 0)}`,

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
@@ -165,7 +165,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
     filterParts = [...filterParts, ...this.filterController.getActiveFilterOdata()];
 
     const odataParts = [
-      'select=Id,Recipients,SentDate,Subject'+(isDevelopment ? ',IsTestMessage' : ''),
+      `select=Id,Recipients,SentDate,Subject${isDevelopment ? ',IsTestMessage' : ''}`,
       'expand=EmailTemplate(select=Id,Name,IsExpired)',
       `top=${await this.dataTable.getTake()}`,
       `orderby=${this.sortBy} ${this.sortDirection}`,

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
@@ -158,11 +158,14 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
     if (endDate) {
       filterParts.push(`SentDate le ${dayjs(endDate).format('YYYY-MM-DD')}`);
     }
+    if (!isDevelopment) {
+      filterParts.push('IsTestMessage eq false');
+    }
 
     filterParts = [...filterParts, ...this.filterController.getActiveFilterOdata()];
 
     const odataParts = [
-      'select=Id,Recipients,SentDate,Subject,IsTestMessage',
+      'select=Id,Recipients,SentDate,Subject'+(isDevelopment ? ',IsTestMessage' : ''),
       'expand=EmailTemplate(select=Id,Name,IsExpired)',
       `top=${await this.dataTable.getTake()}`,
       `orderby=${this.sortBy} ${this.sortDirection}`,

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
@@ -161,7 +161,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
     filterParts = [...filterParts, ...this.filterController.getActiveFilterOdata()];
 
     const odataParts = [
-      'select=Id,Recipients,SentDate,Subject',
+      'select=Id,Recipients,SentDate,Subject,IsTestMessage',
       'expand=EmailTemplate(select=Id,Name,IsExpired)',
       `top=${await this.dataTable.getTake()}`,
       `orderby=${this.sortBy} ${this.sortDirection}`,
@@ -294,6 +294,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
         <titanium-data-table-header
           desktop
           slot="table-headers"
+          width="150px"
           column-name="Recipients"
           title="Recipients"
           @sort-by-changed=${this.#onSortByChange}
@@ -304,6 +305,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
 
         <titanium-data-table-header
           desktop
+          width="150px"
           slot="table-headers"
           column-name="EmailTemplate/Name"
           title="Email template"
@@ -312,6 +314,19 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
           .sortDirection=${this.sortDirection}
           @sort-direction-changed=${this.#onSortDirectionChange}
         ></titanium-data-table-header>
+
+        <titanium-data-table-header
+          width="50px"
+          desktop
+          slot="table-headers"
+          column-name="IsTestMessage"
+          title="Test"
+          @sort-by-changed=${this.#onSortByChange}
+          .sortBy=${this.sortBy}
+          .sortDirection=${this.sortDirection}
+          @sort-direction-changed=${this.#onSortDirectionChange}
+        ></titanium-data-table-header>
+
         <titanium-data-table-header width="50px" no-sort slot="table-headers"></titanium-data-table-header>
         ${repeat(
           this.logs ?? [],
@@ -323,12 +338,13 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
                   ? html`${dayjs(item.SentDate).format('MMM DD, YY')}<br /><span time>${dayjs(item.SentDate).format('h:mm A')}</span>`
                   : '-'}</row-item
               >
-              <row-item large>${item.Subject ?? '-'} </row-item>
-              <row-item desktop title=${item.Recipients ?? ''}>${this.renderRecipients(item.Recipients ?? null)}</row-item>
-              <row-item desktop>
+              <row-item large ellipsis>${item.Subject ?? '-'}</row-item>
+              <row-item desktop width="150px" title=${item.Recipients ?? ''}>${this.renderRecipients(item.Recipients ?? null)}</row-item>
+              <row-item desktop width="150px">
                 <div>${item.EmailTemplate?.Name}</div>
                 ${item.EmailTemplate?.IsExpired ? html`<div inactive>Inactive</div>` : ''}</row-item
               >
+              <row-item width="50px" desktop title="Test Message"><div>${item.IsTestMessage ? 'Yes' : 'No'}</div></row-item>
               <row-item width="50px"
                 ><md-filled-tonal-icon-button @click=${() => this.viewDialog.open(item.Id ?? 0)}><md-icon>pageview</md-icon></md-filled-tonal-icon-button>
               </row-item>

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
@@ -27,12 +27,13 @@ import { ShowSnackbarEvent } from '../../titanium/snackbar/show-snackbar-event';
 import { a } from '../../titanium/styles/a';
 import { ellipsis } from '../../titanium/styles/ellipsis';
 import { DOMEvent } from '../../titanium/types/dom-event';
-import { LitElement, PropertyValues, css, html } from 'lit';
+import { LitElement, PropertyValues, css, html, nothing } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
 import { FilterKeys, LeavittEmailHistoryViewListFilterDialog } from './email-history-view-list-filter-dialog';
 import { LeavittViewSentEmailDialog } from './view-sent-email-dialog';
 import ApiService from '../api-service/api-service';
 import { LeavittViewEmailTemplateInfoDialog } from './view-email-template-info-dialog';
+import { isDevelopment } from '@leavittsoftware/web/titanium/helpers/is-development';
 
 /**
  * @element leavitt-email-history-viewer
@@ -315,7 +316,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
           @sort-direction-changed=${this.#onSortDirectionChange}
         ></titanium-data-table-header>
 
-        <titanium-data-table-header
+        ${isDevelopment ? html`<titanium-data-table-header
           width="50px"
           desktop
           slot="table-headers"
@@ -325,7 +326,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
           .sortBy=${this.sortBy}
           .sortDirection=${this.sortDirection}
           @sort-direction-changed=${this.#onSortDirectionChange}
-        ></titanium-data-table-header>
+        ></titanium-data-table-header>` : nothing}
 
         <titanium-data-table-header width="50px" no-sort slot="table-headers"></titanium-data-table-header>
         ${repeat(
@@ -344,7 +345,7 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
                 <div>${item.EmailTemplate?.Name}</div>
                 ${item.EmailTemplate?.IsExpired ? html`<div inactive>Inactive</div>` : ''}</row-item
               >
-              <row-item width="50px" desktop title="Test Message"><div>${item.IsTestMessage ? 'Yes' : 'No'}</div></row-item>
+              ${isDevelopment ? html`<row-item width="50px" desktop title="Test Message"><div>${item.IsTestMessage ? 'Yes' : 'No'}</div></row-item>` : nothing}
               <row-item width="50px"
                 ><md-filled-tonal-icon-button @click=${() => this.viewDialog.open(item.Id ?? 0)}><md-icon>pageview</md-icon></md-filled-tonal-icon-button>
               </row-item>


### PR DESCRIPTION
Closes #722 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OData query and filtering for email history to conditionally include/exclude `IsTestMessage`, which can affect what records are returned in production if the flag or environment detection is incorrect.
> 
> **Overview**
> Adds an environment-gated **“Test” (`IsTestMessage`) column** to both `email-history-viewer` variants (standard and `-filled`) when running in development.
> 
> Updates the email log OData queries to **select `IsTestMessage` in dev** and to **filter out test messages (`IsTestMessage eq false`) outside dev**, and tweaks a couple table column widths/ellipsis to fit the new column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44297abb1ff690d9aa1305eed5d587dd835de98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->