### PR TITLE
Fix(drawer): Prevent drawer from closing during text selection

### DIFF
--- a/packages/web/titanium/drawer/drawer.ts
+++ b/packages/web/titanium/drawer/drawer.ts
@@ -91,8 +91,15 @@ export class TitaniumDrawer extends LitElement {
       }
     });
 
+    let mousedownTarget: EventTarget | null = null;
+    this.dialog?.addEventListener('mousedown', (e) => {
+      mousedownTarget = e.target;
+    });
+
     this.dialog?.addEventListener('click', (e) => {
-      if (e.target instanceof Element && e.target?.nodeName === 'DIALOG') {
+      const clickedBackdrop = e.target instanceof Element && e.target.nodeName === 'DIALOG';
+      const mousedownOnBackdrop = mousedownTarget instanceof Element && mousedownTarget.nodeName === 'DIALOG';
+      if (clickedBackdrop && mousedownOnBackdrop) {
         this.close();
       }
     });


### PR DESCRIPTION
## Summary
- Fixes an issue where the titanium drawer could close unexpectedly when a user selects text by clicking and dragging outside the content area
- The backdrop-close click handler now tracks the `mousedown` origin so that only clicks where both mousedown and mouseup target the `<dialog>` element trigger a close
- Applies to both flyover and inline modes

## Test plan
- [ ] Open a titanium drawer in flyover mode, select text by click-dragging — verify the drawer stays open
- [ ] Open a titanium drawer in inline mode, select text by click-dragging — verify the drawer stays open
- [ ] Click the backdrop in flyover mode — verify the drawer still closes as expected


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI event-handling change confined to `titanium-drawer` backdrop click detection; main risk is altering expected close behavior for some click sequences.
> 
> **Overview**
> Prevents `titanium-drawer` from closing during text selection/click-drag by tightening the backdrop-close logic.
> 
> The drawer now records the `mousedown` target and only closes on `click` when *both* `mousedown` and `click` originate on the `<dialog>` backdrop, reducing accidental closes while preserving normal backdrop clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41dbc11d0d9e47b298282a2710a41615acfbbbd0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->