### PR TITLE
fix(profile-picture): add background and hide alt text while loading

### DIFF
--- a/packages/web/leavitt/profile-picture/profile-picture.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture.ts
@@ -92,6 +92,7 @@ export class ProfilePicture extends LitElement {
       width: 100%;
       aspect-ratio: 1;
       image-rendering: -webkit-optimize-contrast;
+      background-color: var(--md-sys-color-surface-container-high);
     }
 
     md-icon {
@@ -157,7 +158,8 @@ export class ProfilePicture extends LitElement {
       <img
         loading="lazy"
         draggable="false"
-        alt="User profile picture"
+        data-alt="User profile picture"
+        onload="this.alt = this.getAttribute('data-alt')"
         src=${this.#getFilePath(this.fileName, this.size)}
         @error=${(e: DOMEvent<HTMLImageElement>) => {
           if (e.target.src !== this.#fallbackSrc) {

--- a/packages/web/leavitt/profile-picture/profile-picture.ts
+++ b/packages/web/leavitt/profile-picture/profile-picture.ts
@@ -158,12 +158,15 @@ export class ProfilePicture extends LitElement {
       <img
         loading="lazy"
         draggable="false"
-        data-alt="User profile picture"
-        onload="this.alt = this.getAttribute('data-alt')"
         src=${this.#getFilePath(this.fileName, this.size)}
+        @load=${(e: DOMEvent<HTMLImageElement>) => {
+          e.target.alt = 'User profile picture';
+        }}
         @error=${(e: DOMEvent<HTMLImageElement>) => {
           if (e.target.src !== this.#fallbackSrc) {
             e.target.src = this.#fallbackSrc;
+          } else {
+            e.target.alt = 'User profile picture';
           }
         }}
       />


### PR DESCRIPTION
## Summary
- Adds a `background-color` (`surface-container-high`) to the profile picture `img` element so a subtle placeholder is visible while the image loads, preventing layout flash.
- Hides the `alt` text during loading by moving it to `data-alt` and restoring it via `onload`, so users don't see a raw "User profile picture" text flash before the image appears.

## Test plan
- [ ] Verify profile pictures display with a subtle background color before the image loads
- [ ] Verify alt text is not visible during image load but is set correctly after load completes
- [ ] Verify fallback behavior still works when image fails to load
- [ ] Verify circle and square shapes render correctly

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, limited to visual/UX tweaks in the `profile-picture` web component; primary risk is minor accessibility/CSP behavior changes from setting `alt` via `onload`.
> 
> **Overview**
> Improves `profile-picture` loading UX by adding a themed `background-color` to the `<img>` so a subtle placeholder is shown before the image renders.
> 
> Defers setting the image `alt` text until the image `onload` event (moving it to `data-alt` initially) to prevent the alt string from flashing during load, while keeping existing error fallback behavior intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2d8d6d6cc5f98d6b2765861e8adf7988646295. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->