### PR TITLE
fix(smart-attachment-input): hide rotate buttons when constrainSelectionTo defaults to 'image'

### DIFF
--- a/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
+++ b/packages/web/titanium/smart-attachment-input/crop-and-save-image-dialog.ts
@@ -98,6 +98,20 @@ export class CropAndSaveImageDialog extends LoadWhile(LitElement) {
     this.reset();
     this.fileName = filename;
     this.src = url;
+
+    if (!this.options) {
+      this.options = {};
+    }
+
+    if (this.options.maximizeSelection === undefined) {
+      this.options.maximizeSelection = true;
+    }
+
+    if (this.options.constrainSelectionTo === undefined) {
+      this.options.constrainSelectionTo = 'image';
+    }
+
+    this.requestUpdate();
     await this.updateComplete;
     this.dialog.show();
 
@@ -108,22 +122,6 @@ export class CropAndSaveImageDialog extends LoadWhile(LitElement) {
       const rect = this.cropperCanvas.getBoundingClientRect();
       const canvasRatio = rect.width / rect.height;
       const selectionRatio = this.options?.shape === 'circle' ? 1 : (this.options?.selectionAspectRatio ?? canvasRatio);
-
-      // Temporarily disable selection constraint to prevent issues while image and
-      // and selection are being setup. Prevent off-center and 1px default selections.
-      if (!this.options) {
-        this.options = {};
-      }
-
-      // Default maximizeSelection to true if not explicitly set
-      if (this.options.maximizeSelection === undefined) {
-        this.options.maximizeSelection = true;
-      }
-
-      // Default constrainSelectionTo to 'image' if not explicitly set
-      if (this.options.constrainSelectionTo === undefined) {
-        this.options.constrainSelectionTo = 'image';
-      }
 
       const constrain = this.options.constrainSelectionTo;
       this.options.constrainSelectionTo = null;


### PR DESCRIPTION
https://github.com/LeavittSoftware/titanium-elements/issues/727
Move options defaulting logic before the render cycle so the hidden
binding evaluates correctly on initial dialog open.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only reorders default initialization of `options` to affect initial dialog rendering; no data handling or backend behavior changes.
> 
> **Overview**
> Ensures `crop-and-save-image-dialog` initializes `options` defaults (`maximizeSelection` and `constrainSelectionTo`) *before* the first render/update cycle when `open()` is called.
> 
> This makes initial template bindings (notably the rotate button `hidden` state when `constrainSelectionTo` defaults to `'image'`) evaluate correctly on first dialog open, while keeping the existing cropper setup logic unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5876074969efcd5f97d2009dcd2af9f24586c1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->