### PR TITLE
fix(leavittbook): remove raw demo file copy that broke published build

### DIFF
--- a/packages/leavittbook/rollup.config.js
+++ b/packages/leavittbook/rollup.config.js
@@ -67,7 +67,6 @@ export default {
         { src: 'fonts', dest: 'dist' },
         { src: 'images', dest: 'dist' },
         { src: '404.html', dest: 'dist' },
-        { src: 'src/demos/*', dest: 'dist/src/demos' },
       ],
     }),
   ],


### PR DESCRIPTION
## Summary
- Removed `{ src: 'src/demos/*', dest: 'dist/src/demos' }` from the rollup copy plugin targets
- The copy was placing raw TypeScript-compiled `.js` files (containing bare module specifiers like `@leavittsoftware/web/...`) into `dist/src/demos/`, which the browser cannot resolve — it only understands paths starting with `/`, `./`, or `../`
- The demos are already properly bundled by Rollup through the dynamic `import()` calls in `my-app.ts`, so the raw copy was unnecessary

## Test plan
- [ ] Run `npm run build` and verify it completes without errors
- [ ] Run `npm run start:build` and navigate to demo pages (e.g. Company Select, Person Select) — confirm they load without `TypeError: Failed to resolve module specifier` errors
- [ ] Verify the `dist/` output no longer contains a `src/demos/` directory with raw `.js` files

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-packaging change limited to Rollup asset copying; main risk is demos/assets no longer being present if anything depended on the raw `dist/src/demos` output.
> 
> **Overview**
> Removes the Rollup copy target that was copying `src/demos/*` directly into `dist/src/demos`, so published builds no longer include raw, unbundled demo JS files.
> 
> This relies on Rollup’s normal bundling (via the app’s imports) for demos instead of shipping the copied source output, avoiding browser module-specifier resolution issues in the built `dist/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6942470265adcd4b10d2e0f1dc0f23058a8865f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->