### PR TITLE
Resets dirty state reliably after data fetch

### DIFF
--- a/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
@@ -185,7 +185,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
         getSortExpression: () => 'IsTestMessage',
         render: (item) => html`<div>${item.IsTestMessage ? 'Yes' : 'No'}</div>`,
         csvValue: (item) => (item.IsTestMessage ? 'Yes' : 'No'),
-        width: '50px'
+        width: '50px',
       });
     }
   }

--- a/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer.ts
@@ -183,9 +183,10 @@ export default class LeavittEmailHistoryViewer extends LoadWhile(LitElement) {
       const result = await get;
       this.resultTotal = result.odataCount;
       this.logs = result.toList();
-      this.#isDirty = false;
     } catch (error) {
       this.dispatchEvent(new ShowSnackbarEvent(error));
+    } finally {
+      this.#isDirty = false;
     }
   }
 


### PR DESCRIPTION
Moves the state reset logic to the `finally` block of the data fetching operation. This change ensures that the component's internal 'dirty' flag is always cleared after a data fetch attempt, regardless of whether the operation was successful or resulted in an error. This prevents the component from remaining in a stale or loading state in the event of a fetch failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change that only affects the internal `#isDirty` state after a fetch attempt, plus a trivial formatting fix.
> 
> **Overview**
> Ensures `leavitt-email-history-viewer` always clears its internal `#isDirty` flag after `#getLogsAsync` completes by moving the reset into a `finally` block, so failed requests don’t leave the component stuck in a dirty/loading state.
> 
> Also adds a trailing comma in `email-history-viewer-filled.ts` metadata for the development-only `IsTestMessage` column (formatting-only change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2949d2fa01d055c5b6d0d962b5b23a991faf8c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->