### PR TITLE
chore: update demos to use shared api service

### DIFF
--- a/packages/leavittbook/src/demos/leavitt-email-history-viewer-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-email-history-viewer-demo.ts
@@ -30,7 +30,9 @@ export class LeavittEmailHistoryViewerDemo extends ThemePreference(LitElement) {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    api3UserService.addHeader('X-LGAppName', 'Testing');
+    if (api3UserService.headers['X-LGAppName'] === 'EducationAdminV2') {
+      api3UserService.addHeader('X-LGAppName', 'Testing');
+    }
   }
   static styles = [
     StoryStyles,

--- a/packages/leavittbook/src/demos/leavitt-email-history-viewer-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-email-history-viewer-demo.ts
@@ -9,29 +9,29 @@ import '@leavittsoftware/web/leavitt/email-history-viewer/email-history-viewer';
 import '@leavittsoftware/web/leavitt/email-history-viewer/email-history-viewer-filled';
 
 import { css, html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 import { ThemePreference } from '@leavittsoftware/web/leavitt/theme/theme-preference';
 
-import ApiService from '@leavittsoftware/web/leavitt/api-service/api-service';
 import LeavittEmailHistoryViewer from '@leavittsoftware/web/leavitt/email-history-viewer/email-history-viewer';
 import LeavittEmailHistoryViewerFilled from '@leavittsoftware/web/leavitt/email-history-viewer/email-history-viewer-filled';
-import UserManager from '../services/user-manager-service';
 import StoryStyles from '../styles/story-styles';
 import { siteSearchTextFieldContext } from '../contexts/site-search-text-field-context';
+import api3UserService from '../services/api3-user-service';
 
 @customElement('leavitt-email-history-viewer-demo')
 export class LeavittEmailHistoryViewerDemo extends ThemePreference(LitElement) {
-  @state() private accessor apiService: ApiService;
   @query('leavitt-email-history-viewer') protected accessor demo1!: LeavittEmailHistoryViewer;
   @query('leavitt-email-history-viewer-filled') protected accessor demo2!: LeavittEmailHistoryViewerFilled;
 
-  constructor() {
-    super();
-    this.apiService = new ApiService(UserManager);
-    this.apiService.baseUrl = 'https://devapi3.leavitt.com/';
-    this.apiService.addHeader('X-LGAppName', 'EducationAdminV2');
+  connectedCallback() {
+    super.connectedCallback();
+    api3UserService.addHeader('X-LGAppName', 'EducationAdminV2');
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    api3UserService.addHeader('X-LGAppName', 'Testing');
+  }
   static styles = [
     StoryStyles,
     css`
@@ -58,7 +58,7 @@ export class LeavittEmailHistoryViewerDemo extends ThemePreference(LitElement) {
                 <leavitt-email-history-viewer-filled
                   isActive
                   .siteSearchTextFieldContext=${siteSearchTextFieldContext}
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                   .path=${'/leavitt-email-history-viewer'}
                 ></leavitt-email-history-viewer-filled>
               </div>
@@ -72,7 +72,7 @@ export class LeavittEmailHistoryViewerDemo extends ThemePreference(LitElement) {
             <div>
               <h1>Outlined</h1>
               <div row>
-                <leavitt-email-history-viewer isActive .apiService=${this.apiService} .path=${'/leavitt-email-history-viewer'}></leavitt-email-history-viewer>
+                <leavitt-email-history-viewer isActive .apiService=${api3UserService} .path=${'/leavitt-email-history-viewer'}></leavitt-email-history-viewer>
               </div>
             </div>
 

--- a/packages/leavittbook/src/demos/leavitt-file-explorer-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-file-explorer-demo.ts
@@ -8,21 +8,21 @@ import '@leavittsoftware/web/titanium/snackbar/snackbar-stack';
 import '@leavittsoftware/web/leavitt/file-explorer/file-explorer';
 
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
-import ApiService from '@leavittsoftware/web/leavitt/api-service/api-service';
-import UserManager from '../services/user-manager-service';
+import { customElement } from 'lit/decorators.js';
 
 import StoryStyles from '../styles/story-styles';
+import api3UserService from '../services/api3-user-service';
 
 @customElement('leavitt-file-explorer-demo')
 export class LeavittFileExplorerDemo extends LitElement {
-  @state() private accessor fileExplorerApiService: ApiService;
+  connectedCallback() {
+    super.connectedCallback();
+    api3UserService.addHeader('X-LGAppName', 'FileExplorer');
+  }
 
-  constructor() {
-    super();
-    this.fileExplorerApiService = new ApiService(UserManager);
-    this.fileExplorerApiService.baseUrl = 'https://devapi3.leavitt.com/';
-    this.fileExplorerApiService.addHeader('X-LGAppName', 'FileExplorer');
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    api3UserService.addHeader('X-LGAppName', 'Testing');
   }
 
   static styles = [StoryStyles];
@@ -39,7 +39,7 @@ export class LeavittFileExplorerDemo extends LitElement {
             <div>
               <h1>File Explorer</h1>
               <p>File explorer component with API integration</p>
-              <leavitt-file-explorer file-explorer-id="1" .apiService=${this.fileExplorerApiService}></leavitt-file-explorer>
+              <leavitt-file-explorer file-explorer-id="1" .apiService=${api3UserService}></leavitt-file-explorer>
             </div>
 
             <api-docs src="./custom-elements.json" selected="leavitt-file-explorer"></api-docs>

--- a/packages/leavittbook/src/demos/leavitt-file-explorer-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-file-explorer-demo.ts
@@ -22,7 +22,9 @@ export class LeavittFileExplorerDemo extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    api3UserService.addHeader('X-LGAppName', 'Testing');
+    if (api3UserService.headers['X-LGAppName'] === 'FileExplorer') {
+      api3UserService.addHeader('X-LGAppName', 'Testing');
+    }
   }
 
   static styles = [StoryStyles];

--- a/packages/leavittbook/src/demos/leavitt-person-company-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-company-select-demo.ts
@@ -9,24 +9,15 @@ import '@leavittsoftware/web/leavitt/person-company-select/person-company-select
 import '@leavittsoftware/web/titanium/snackbar/snackbar-stack';
 
 import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 import { LeavittPersonCompanySelect } from '@leavittsoftware/web/leavitt/person-company-select/person-company-select';
 
-import ApiService from '@leavittsoftware/web/leavitt/api-service/api-service';
-import UserManager from '../services/user-manager-service';
 import StoryStyles from '../styles/story-styles';
+import api3UserService from '../services/api3-user-service';
 
 @customElement('leavitt-person-company-select-demo')
 export class LeavittPersonCompanySelectDemo extends LitElement {
-  @state() private accessor apiService: ApiService;
   @query('leavitt-person-company-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonCompanySelect;
-
-  constructor() {
-    super();
-    this.apiService = new ApiService(UserManager);
-    this.apiService.baseUrl = 'https://devapi3.leavitt.com/';
-    this.apiService.addHeader('X-LGAppName', 'Testing');
-  }
 
   static styles = [StoryStyles];
 
@@ -43,7 +34,7 @@ export class LeavittPersonCompanySelectDemo extends LitElement {
             <div>
               <h1>Methods</h1>
               <item-row>
-                <leavitt-person-company-select required methods-demo .apiService=${this.apiService}></leavitt-person-company-select>
+                <leavitt-person-company-select required methods-demo .apiService=${api3UserService}></leavitt-person-company-select>
               </item-row>
               <section buttons>
                 <md-filled-tonal-button @click=${() => this.methodsSelect.reset()}>reset()</md-filled-tonal-button>
@@ -55,15 +46,15 @@ export class LeavittPersonCompanySelectDemo extends LitElement {
             <div>
               <h1>Attributes</h1>
               <item-row>
-                <leavitt-person-company-select label="default" .apiService=${this.apiService}></leavitt-person-company-select>
-                <leavitt-person-company-select label="shaped" shaped .apiService=${this.apiService}></leavitt-person-company-select>
+                <leavitt-person-company-select label="default" .apiService=${api3UserService}></leavitt-person-company-select>
+                <leavitt-person-company-select label="shaped" shaped .apiService=${api3UserService}></leavitt-person-company-select>
                 <leavitt-person-company-select
                   label="pre-selected"
                   .selected=${{
                     Name: 'Leavitt Group Enterprises',
                     type: 'Company',
                   } as never}
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-company-select>
                 <leavitt-person-company-select
                   label="disabled pre-selected"
@@ -74,18 +65,18 @@ export class LeavittPersonCompanySelectDemo extends LitElement {
                     ProfilePictureCdnFileName: 'zP6DJ9lM6HmkTAaku8ZIzQQdUBHYrX5pCCANvFxtpnagBhJPp7CGXOl-16xe',
                   } as never}
                   disabled
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-company-select>
                 <leavitt-person-company-select
                   label="placeholder"
                   placeholder="placeholder text"
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-company-select>
                 <leavitt-person-company-select
                   label="required"
                   required
                   validationMessage="required"
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-company-select>
               </item-row>
             </div>

--- a/packages/leavittbook/src/demos/leavitt-person-group-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-group-select-demo.ts
@@ -8,24 +8,15 @@ import '@material/web/button/filled-tonal-button';
 import '@leavittsoftware/web/leavitt/person-group-select/person-group-select';
 
 import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 import { LeavittPersonGroupSelect } from '@leavittsoftware/web/leavitt/person-group-select/person-group-select';
 
-import ApiService from '@leavittsoftware/web/leavitt/api-service/api-service';
-import UserManager from '../services/user-manager-service';
 import StoryStyles from '../styles/story-styles';
+import api3UserService from '../services/api3-user-service';
 
 @customElement('leavitt-person-group-select-demo')
 export class LeavittPersonGroupSelectDemo extends LitElement {
-  @state() private accessor apiService: ApiService;
   @query('leavitt-person-group-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonGroupSelect;
-
-  constructor() {
-    super();
-    this.apiService = new ApiService(UserManager);
-    this.apiService.baseUrl = 'https://devapi3.leavitt.com/';
-    this.apiService.addHeader('X-LGAppName', 'Testing');
-  }
 
   static styles = [StoryStyles];
 
@@ -42,8 +33,8 @@ export class LeavittPersonGroupSelectDemo extends LitElement {
             <div>
               <h1>Default</h1>
               <item-row>
-                <leavitt-person-group-select label="default" .apiService=${this.apiService}></leavitt-person-group-select>
-                <leavitt-person-group-select label="shaped" shaped .apiService=${this.apiService}></leavitt-person-group-select>
+                <leavitt-person-group-select label="default" .apiService=${api3UserService}></leavitt-person-group-select>
+                <leavitt-person-group-select label="shaped" shaped .apiService=${api3UserService}></leavitt-person-group-select>
                 <leavitt-person-group-select
                   label="pre-selected"
                   .selected=${{
@@ -51,7 +42,7 @@ export class LeavittPersonGroupSelectDemo extends LitElement {
                     Id: 22,
                     type: 'PeopleGroup',
                   } as never}
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-group-select>
                 <leavitt-person-group-select
                   label="disabled pre-selected"
@@ -62,14 +53,14 @@ export class LeavittPersonGroupSelectDemo extends LitElement {
                     type: 'Person',
                   } as never}
                   disabled
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-group-select>
-                <leavitt-person-group-select label="placeholder" placeholder="placeholder text" .apiService=${this.apiService}></leavitt-person-group-select>
+                <leavitt-person-group-select label="placeholder" placeholder="placeholder text" .apiService=${api3UserService}></leavitt-person-group-select>
                 <leavitt-person-group-select
                   label="required"
                   required
                   validationMessage="required"
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-group-select>
               </item-row>
             </div>
@@ -77,7 +68,7 @@ export class LeavittPersonGroupSelectDemo extends LitElement {
             <div>
               <h1>Methods</h1>
               <item-row>
-                <leavitt-person-group-select methods-demo required .apiService=${this.apiService}></leavitt-person-group-select>
+                <leavitt-person-group-select methods-demo required .apiService=${api3UserService}></leavitt-person-group-select>
               </item-row>
               <section buttons>
                 <md-filled-tonal-button @click=${() => this.methodsSelect.reset()}>reset()</md-filled-tonal-button>

--- a/packages/leavittbook/src/demos/leavitt-person-select-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-person-select-demo.ts
@@ -9,25 +9,16 @@ import '@leavittsoftware/web/leavitt/profile-picture/profile-picture';
 import '@leavittsoftware/web/leavitt/person-select/person-select';
 
 import { html, LitElement } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, query } from 'lit/decorators.js';
 import { LeavittPersonSelect } from '@leavittsoftware/web/leavitt/person-select/person-select';
 import { Person } from '@leavittsoftware/lg-core-typescript';
 
-import ApiService from '@leavittsoftware/web/leavitt/api-service/api-service';
-import UserManager from '../services/user-manager-service';
 import StoryStyles from '../styles/story-styles';
+import api3UserService from '../services/api3-user-service';
 
 @customElement('leavitt-person-select-demo')
 export class LeavittPersonSelectDemo extends LitElement {
-  @state() private accessor apiService: ApiService;
   @query('leavitt-person-select[methods-demo]') protected accessor methodsSelect!: LeavittPersonSelect;
-
-  constructor() {
-    super();
-    this.apiService = new ApiService(UserManager);
-    this.apiService.baseUrl = 'https://devapi3.leavitt.com/';
-    this.apiService.addHeader('X-LGAppName', 'Testing');
-  }
 
   static styles = [StoryStyles];
 
@@ -42,7 +33,7 @@ export class LeavittPersonSelectDemo extends LitElement {
 
             <div>
               <h1>Methods</h1>
-              <leavitt-person-select required methods-demo .apiService=${this.apiService}></leavitt-person-select>
+              <leavitt-person-select required methods-demo .apiService=${api3UserService}></leavitt-person-select>
               <section buttons>
                 <md-filled-tonal-button @click=${() => this.methodsSelect.reset()}>reset()</md-filled-tonal-button>
                 <md-filled-tonal-button @click=${() => this.methodsSelect.focus()}>focus()</md-filled-tonal-button>
@@ -66,7 +57,7 @@ export class LeavittPersonSelectDemo extends LitElement {
                   'count=true',
                 ]}
                 enable-people-preloading
-                .apiService=${this.apiService}
+                .apiService=${api3UserService}
               ></leavitt-person-select>
             </div>
 
@@ -127,7 +118,7 @@ export class LeavittPersonSelectDemo extends LitElement {
             <div>
               <h1>Attributes</h1>
               <item-row>
-                <leavitt-person-select label="default" .apiService=${this.apiService}></leavitt-person-select>
+                <leavitt-person-select label="default" .apiService=${api3UserService}></leavitt-person-select>
 
                 <leavitt-person-select
                   label="prefilled"
@@ -137,15 +128,15 @@ export class LeavittPersonSelectDemo extends LitElement {
                     CompanyName: 'Leavitt Software Solutions',
                     ProfilePictureCdnFileName: 'zP6DJ9lM6HmkTAaku8ZIzQQdUBHYrX5pCCANvFxtpnagBhJPp7CGXOl-16xe',
                   } as never}
-                  .apiService=${this.apiService}
+                  .apiService=${api3UserService}
                 ></leavitt-person-select>
 
-                <leavitt-person-select label="shaped" shaped .apiService=${this.apiService}></leavitt-person-select>
-                <leavitt-person-select label="placeholder" placeholder="My placeholder" .apiService=${this.apiService}></leavitt-person-select>
-                <leavitt-person-select label="Supporting text" supportingText="supporting text" .apiService=${this.apiService}></leavitt-person-select>
-                <leavitt-person-select label="required" required validationMessage="required" .apiService=${this.apiService}></leavitt-person-select>
-                <leavitt-person-select label="disabled" disabled .apiService=${this.apiService}></leavitt-person-select>
-                <leavitt-person-select label="Suffix text" suffixText="Admin" .apiService=${this.apiService}></leavitt-person-select>
+                <leavitt-person-select label="shaped" shaped .apiService=${api3UserService}></leavitt-person-select>
+                <leavitt-person-select label="placeholder" placeholder="My placeholder" .apiService=${api3UserService}></leavitt-person-select>
+                <leavitt-person-select label="Supporting text" supportingText="supporting text" .apiService=${api3UserService}></leavitt-person-select>
+                <leavitt-person-select label="required" required validationMessage="required" .apiService=${api3UserService}></leavitt-person-select>
+                <leavitt-person-select label="disabled" disabled .apiService=${api3UserService}></leavitt-person-select>
+                <leavitt-person-select label="Suffix text" suffixText="Admin" .apiService=${api3UserService}></leavitt-person-select>
               </item-row>
             </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk demo-only refactor that centralizes API client configuration; main risk is shared singleton header mutation leaking between demos if lifecycle hooks don’t run as expected.
> 
> **Overview**
> Refactors multiple leavittbook demos to stop instantiating their own `ApiService`/`UserManager` clients and instead pass the shared singleton `api3UserService` into components.
> 
> Adds demo lifecycle hooks where needed (e.g., email history viewer and file explorer) to temporarily override the `X-LGAppName` header on connect and reset it on disconnect, and removes now-unused `@state` service fields and dev base URL setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b125dbd18ade0da111229edf9ee6487f5f54b5c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->