### PR TITLE
feat(email-history-viewer-filled): add configurable apiControllerName property

### DIFF
--- a/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
+++ b/packages/web/leavitt/email-history-viewer/email-history-viewer-filled.ts
@@ -53,6 +53,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
   @property({ type: Object }) public accessor apiService: ApiService | null;
   @property({ type: String }) public accessor path: string;
   @property({ type: Object }) public accessor siteSearchTextFieldContext: TitaniumTextFieldSearchContext;
+  @property({ type: String }) accessor apiControllerName: string = 'EmailTemplateLogs';
 
   /**
    * @deprecated use the siteSearchTextFieldController + siteSearchTextFieldContext instead
@@ -149,7 +150,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
   }
 
   async updated(changedProps: PropertyValues<this>) {
-    if (this.isActive && changedProps.has('isActive')) {
+    if (this.isActive && (changedProps.has('isActive') || changedProps.has('apiControllerName'))) {
       await this.mainContentContainer?.updateComplete;
       this.#reload();
     }
@@ -268,7 +269,7 @@ export default class LeavittEmailHistoryViewerFilled extends LoadWhile(LitElemen
         throw new Error('No api service provided');
       }
 
-      const get = this.apiService?.getAsync<ItemType>(`EmailTemplateLogs/?${odataParts.join('&')}`);
+      const get = this.apiService?.getAsync<ItemType>(`${this.apiControllerName}/?${odataParts.join('&')}`);
       this.loadWhile(get);
       this.dataTable.loadWhile(get);
       this.dispatchEvent(new PendingStateEvent(get));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small, localized change that only alters which API controller path the email history viewer queries; misconfiguration could cause the table to stop loading data.
> 
> **Overview**
> `leavitt-email-history-viewer-filled` now exposes an `apiControllerName` property (defaulting to `EmailTemplateLogs`) and uses it to build the OData `getAsync` request path instead of a hard-coded controller.
> 
> The component also triggers a data reload when `apiControllerName` changes while active, so switching controllers updates results immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8183d0e2e203955a429d0da82ee0bab41f82b7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->