### PR TITLE
feat(helpers): add @promiseTracking decorator

### DIFF
--- a/packages/leavittbook/src/demos/titanium-promise-tracking-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-promise-tracking-demo.ts
@@ -1,0 +1,108 @@
+import '../shared/story-header';
+
+import '@leavittsoftware/web/leavitt/app/app-main-content-container';
+import '@leavittsoftware/web/leavitt/app/app-navigation-header';
+import '@leavittsoftware/web/leavitt/app/app-width-limiter';
+
+import '@material/web/button/filled-button';
+import '@material/web/button/filled-tonal-button';
+import '@material/web/progress/linear-progress';
+
+import { css, html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { delay } from '@leavittsoftware/web/titanium/helpers/delay';
+import { promiseTracking } from '@leavittsoftware/web/titanium/helpers/promise-tracking';
+
+import StoryStyles from '../styles/story-styles';
+
+@customElement('titanium-promise-tracking-demo')
+export class TitaniumPromiseTrackingDemo extends LitElement {
+  @promiseTracking('trackLoadingPromise')
+  @state()
+  accessor isLoading = false;
+  declare trackLoadingPromise: (promise: Promise<unknown>) => Promise<void>;
+
+  @promiseTracking('trackDeletingPromise')
+  @state()
+  accessor isDeleting = false;
+  declare trackDeletingPromise: (promise: Promise<unknown>) => Promise<void>;
+
+  #onLoad() {
+    this.trackLoadingPromise(delay(2000));
+  }
+
+  #onDelete() {
+    this.trackDeletingPromise(delay(3000));
+  }
+
+  #onBoth() {
+    this.trackLoadingPromise(delay(2000));
+    this.trackDeletingPromise(delay(3000));
+  }
+
+  static styles = [
+    StoryStyles,
+    css`
+      section {
+        display: grid;
+        gap: 16px;
+        padding: 16px 0;
+      }
+
+      .flags {
+        display: flex;
+        gap: 24px;
+        font-family: 'Roboto Mono', monospace;
+      }
+
+      .progress-stack {
+        display: grid;
+        gap: 8px;
+        max-width: 400px;
+      }
+
+      .actions {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+    `,
+  ];
+
+  render() {
+    return html`
+      <leavitt-app-main-content-container .pendingStateElement=${this}>
+        <main>
+          <leavitt-app-navigation-header level1Text="Promise tracking" level1Href="/titanium-promise-tracking" sticky-top></leavitt-app-navigation-header>
+          <leavitt-app-width-limiter max-width="1000px">
+            <story-header name="Promise tracking" className="promiseTracking"></story-header>
+
+            <section>
+              <h1>Two independent tracked promises</h1>
+              <p>
+                A single component uses <code>@promiseTracking</code> twice to drive two independent reactive boolean flags. Each decorated accessor gets its
+                own counter, so concurrent calls don't interfere with each other.
+              </p>
+
+              <div class="flags">
+                <span>isLoading: <strong>${this.isLoading}</strong></span>
+                <span>isDeleting: <strong>${this.isDeleting}</strong></span>
+              </div>
+
+              <div class="progress-stack">
+                <md-linear-progress aria-label="loading" ?indeterminate=${this.isLoading}></md-linear-progress>
+                <md-linear-progress aria-label="deleting" ?indeterminate=${this.isDeleting}></md-linear-progress>
+              </div>
+
+              <div class="actions">
+                <md-filled-button ?disabled=${this.isLoading} @click=${this.#onLoad}>Start load (2s)</md-filled-button>
+                <md-filled-tonal-button ?disabled=${this.isDeleting} @click=${this.#onDelete}>Start delete (3s)</md-filled-tonal-button>
+                <md-filled-button @click=${this.#onBoth}>Start both concurrently</md-filled-button>
+              </div>
+            </section>
+          </leavitt-app-width-limiter>
+        </main>
+      </leavitt-app-main-content-container>
+    `;
+  }
+}

--- a/packages/leavittbook/src/my-app.ts
+++ b/packages/leavittbook/src/my-app.ts
@@ -175,6 +175,9 @@ export class MyApp extends PendingStateCatcher(LitElement) {
     page('/titanium-input-validator', () => this.#changePage('titanium-input-validator', () => import('./demos/titanium-input-validator-demo.js')));
     page('/titanium-data-table-header', () => this.#changePage('titanium-data-table-header', () => import('./demos/titanium-data-table-header-demo.js')));
     page('/titanium-data-table-core', () => this.#changePage('titanium-data-table-core', () => import('./demos/titanium-data-table-core-demo.js')));
+    page('/titanium-promise-tracking', () =>
+      this.#changePage('titanium-promise-tracking', () => import('./demos/titanium-promise-tracking-demo.js'))
+    );
 
     page('/titanium-full-page-loading-indicator', () =>
       this.#changePage('titanium-full-page-loading-indicator', () => import('./demos/titanium-full-page-loading-indicator-demo.js'))
@@ -444,6 +447,10 @@ export class MyApp extends PendingStateCatcher(LitElement) {
             <md-icon slot="start">groups</md-icon> <span>Profile picture stack</span>
           </md-list-item>
 
+          <md-list-item ?selected=${this.page === 'titanium-promise-tracking'} href="/titanium-promise-tracking" type="link">
+            <md-icon slot="start">hourglass_top</md-icon> <span>Promise tracking</span>
+          </md-list-item>
+
           <md-list-item ?selected=${!!this.page?.includes('titanium-search-input')} href="/titanium-search-input" type="link">
             <md-icon slot="start">search</md-icon> <span>Search input </span>
           </md-list-item>
@@ -583,6 +590,11 @@ export class MyApp extends PendingStateCatcher(LitElement) {
           : nothing}
         ${this.page === 'titanium-data-table-core'
           ? html` <titanium-data-table-core-demo large ?isActive=${this.page === 'titanium-data-table-core'}></titanium-data-table-core-demo> `
+          : nothing}
+        ${this.page === 'titanium-promise-tracking'
+          ? html`
+              <titanium-promise-tracking-demo large ?isActive=${this.page === 'titanium-promise-tracking'}></titanium-promise-tracking-demo>
+            `
           : nothing}
         ${this.page === 'titanium-data-table-header'
           ? html` <titanium-data-table-header-demo large ?isActive=${this.page === 'titanium-data-table-header'}></titanium-data-table-header-demo> `

--- a/packages/web/titanium/helpers/helpers.ts
+++ b/packages/web/titanium/helpers/helpers.ts
@@ -6,6 +6,7 @@ export { installMediaQueryWatcher } from './install-media-query-watcher';
 export { getSearchTokens } from './get-search-token';
 export { Debouncer } from './debouncer';
 export { LoadWhile } from './load-while';
+export { promiseTracking } from './promise-tracking';
 export { join } from './join';
 export { delay } from './delay';
 export { middleEllipsis } from './middle-ellipsis';

--- a/packages/web/titanium/helpers/promise-tracking.ts
+++ b/packages/web/titanium/helpers/promise-tracking.ts
@@ -1,0 +1,44 @@
+/**
+ * Decorates a reactive boolean accessor so that calling the generated method
+ * sets the property to `true` while the supplied promise is pending, and
+ * back to `false` once it resolves or rejects. Re-throws errors.
+ *
+ * Reentrancy: if the method is called multiple times concurrently, the
+ * property only flips back to `false` after ALL outstanding promises settle.
+ *
+ * Because the method name is a runtime string, TypeScript can't see it on
+ * the host class. Consumers add a one-line `declare` next to the accessor.
+ *
+ * @param methodName The name of the method to add to the host prototype.
+ *
+ * @example
+ * ```ts
+ * \@promiseTracking('trackLoadingPromise')
+ * \@state() accessor isLoading = false;
+ * declare trackLoadingPromise: (p: Promise<unknown>) => Promise<void>;
+ *
+ * await this.trackLoadingPromise(api.load());
+ * ```
+ */
+export function promiseTracking(methodName: string) {
+  return function (target: object, propertyKey: string | symbol, _descriptor: PropertyDescriptor): void {
+    const counterKey = Symbol(`__${String(propertyKey)}_count__`);
+
+    Object.defineProperty(target, methodName, {
+      configurable: true,
+      writable: true,
+      value: async function (this: any, promise: Promise<unknown>) {
+        this[counterKey] = (this[counterKey] ?? 0) + 1;
+        this[propertyKey] = true;
+        try {
+          await promise;
+        } finally {
+          this[counterKey]--;
+          if (this[counterKey] === 0) {
+            this[propertyKey] = false;
+          }
+        }
+      },
+    });
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `@promiseTracking(methodName)` decorator in `packages/web/titanium/helpers/promise-tracking.ts`. Decorating a reactive boolean accessor (e.g. `@state() accessor isDeleting = false`) attaches a sibling method on the prototype that flips the property to `true` while a supplied promise is pending and back to `false` once it settles. Each decorated property gets its own per-instance concurrency counter, so a component can track multiple independent loading states (e.g. `isLoading` and `isDeleting`) without stacking the existing `LoadWhile` mixin. Errors are re-thrown so callers can handle them.
- Re-exported from `packages/web/titanium/helpers/helpers.ts` next to `LoadWhile`.
- New leavittbook demo `titanium-promise-tracking-demo` with two `@promiseTracking` decorators on a single class plus a "Start both concurrently" button to demonstrate independence; wired into `my-app.ts` (route, nav entry, render block).
- The existing `LoadWhile` mixin and its 17 call sites are left untouched.

## Usage

```ts
class Foo extends LitElement {
  @promiseTracking('trackDeletingPromise')
  @state() accessor isDeleting = false;

  async #onDelete() {
    await this.trackDeletingPromise(api.delete(this.id));
  }
}
```

Because the method name is a runtime string, TypeScript can't infer it on the class, so a one-line `declare` next to the accessor types the call site.

## Test plan

- [ ] `npm run build` succeeds
- [ ] Open leavittbook, navigate to "Promise tracking" in the side nav
- [ ] Click "Start load (2s)" -- isLoading flips true, top progress bar shows for ~2s, then false
- [ ] Click "Start delete (3s)" -- isDeleting flips true independently
- [ ] Click "Start both concurrently" -- both flags rise; isLoading falls at ~2s while isDeleting stays true until ~3s
- [ ] Spam-click "Start load (2s)" twice quickly -- isLoading stays true until both promises settle (counter reentrancy)
