### PR TITLE
feat(error-page): accept string | TemplateResult for heading and message

### DIFF
--- a/packages/leavittbook/src/demos/leavitt-error-page-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-error-page-demo.ts
@@ -12,8 +12,6 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import StoryStyles from '../styles/story-styles';
-import { a } from '@leavittsoftware/web/titanium/styles/a';
-import { p } from '@leavittsoftware/web/titanium/styles/p';
 
 @customElement('leavitt-error-page-demo')
 export class LeavittErrorPageDemo extends LitElement {
@@ -44,11 +42,7 @@ export class LeavittErrorPageDemo extends LitElement {
               <md-divider></md-divider>
               <leavitt-error-page
                 .heading=${html`Page not found`}
-                .message=${html` <style>
-                    ${p}
-                    ${a}
-                  </style>
-                  <p>The page you requested could not be found. <a href="/">Return home</a> or <a href="mailto:support@leavitt.com">contact support</a>.</p>`}
+                .message=${html`The page you requested could not be found. <a style="color: var(--md-sys-color-primary)" href="/">Return home</a> or <a style="color: var(--md-sys-color-primary)" href="mailto:support@leavitt.com">contact support</a>.`}
               ></leavitt-error-page>
             </div>
 

--- a/packages/leavittbook/src/demos/leavitt-error-page-demo.ts
+++ b/packages/leavittbook/src/demos/leavitt-error-page-demo.ts
@@ -12,6 +12,8 @@ import { css, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import StoryStyles from '../styles/story-styles';
+import { a } from '@leavittsoftware/web/titanium/styles/a';
+import { p } from '@leavittsoftware/web/titanium/styles/p';
 
 @customElement('leavitt-error-page-demo')
 export class LeavittErrorPageDemo extends LitElement {
@@ -39,6 +41,15 @@ export class LeavittErrorPageDemo extends LitElement {
               <leavitt-error-page heading="Sorry!" message="It looks like you don't have access to this area."
                 ><md-icon slot="icon">lock</md-icon></leavitt-error-page
               >
+              <md-divider></md-divider>
+              <leavitt-error-page
+                .heading=${html`Page not found`}
+                .message=${html` <style>
+                    ${p}
+                    ${a}
+                  </style>
+                  <p>The page you requested could not be found. <a href="/">Return home</a> or <a href="mailto:support@leavitt.com">contact support</a>.</p>`}
+              ></leavitt-error-page>
             </div>
 
             <api-docs src="./custom-elements.json" selected="leavitt-error-page"></api-docs>

--- a/packages/leavittbook/src/demos/titanium-error-page-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-error-page-demo.ts
@@ -11,6 +11,8 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import StoryStyles from '../styles/story-styles';
+import { a } from '@leavittsoftware/web/titanium/styles/a';
+import { p } from '@leavittsoftware/web/titanium/styles/p';
 
 @customElement('titanium-error-page-demo')
 export class TitaniumErrorPageDemo extends LitElement {
@@ -26,6 +28,14 @@ export class TitaniumErrorPageDemo extends LitElement {
             <div>
               <h1>Default</h1>
               <titanium-error-page message="You can customize this message"></titanium-error-page>
+              <h1>TemplateResult message</h1>
+              <titanium-error-page
+                .message=${html` <style>
+                    ${p}
+                    ${a}
+                  </style>
+                  <p>We couldn't find that page. <a href="/">Go back home</a> or <a href="mailto:support@leavitt.com">contact support</a>.</p>`}
+              ></titanium-error-page>
             </div>
             <api-docs src="./custom-elements.json" selected="titanium-error-page"></api-docs>
           </leavitt-app-width-limiter>

--- a/packages/leavittbook/src/demos/titanium-error-page-demo.ts
+++ b/packages/leavittbook/src/demos/titanium-error-page-demo.ts
@@ -11,8 +11,6 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 import StoryStyles from '../styles/story-styles';
-import { a } from '@leavittsoftware/web/titanium/styles/a';
-import { p } from '@leavittsoftware/web/titanium/styles/p';
 
 @customElement('titanium-error-page-demo')
 export class TitaniumErrorPageDemo extends LitElement {
@@ -30,11 +28,7 @@ export class TitaniumErrorPageDemo extends LitElement {
               <titanium-error-page message="You can customize this message"></titanium-error-page>
               <h1>TemplateResult message</h1>
               <titanium-error-page
-                .message=${html` <style>
-                    ${p}
-                    ${a}
-                  </style>
-                  <p>We couldn't find that page. <a href="/">Go back home</a> or <a href="mailto:support@leavitt.com">contact support</a>.</p>`}
+                .message=${html`We couldn't find that page. <a style="color: var(--md-sys-color-primary)" href="/">Go back home</a> or <a style="color: var(--md-sys-color-primary)" href="mailto:support@leavitt.com">contact support</a>.`}
               ></titanium-error-page>
             </div>
             <api-docs src="./custom-elements.json" selected="titanium-error-page"></api-docs>

--- a/packages/web/leavitt/error-page/error-page.ts
+++ b/packages/web/leavitt/error-page/error-page.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, TemplateResult } from 'lit';
 import { property, customElement, query } from 'lit/decorators.js';
 
 import '../app/app-main-content-container';
@@ -21,8 +21,8 @@ export class LeavittErrorPage extends ThemePreference(LitElement) {
   /**
    * Reason text for the error
    */
-  @property({ type: String }) accessor heading: string = 'Hmm...';
-  @property({ type: String }) accessor message: string = "It looks like that page doesn't exist.";
+  @property() accessor heading: string | TemplateResult<1> = 'Hmm...';
+  @property() accessor message: string | TemplateResult<1> = "It looks like that page doesn't exist.";
 
   @query('div[particles]') private accessor particlesContainer: HTMLDivElement;
 

--- a/packages/web/titanium/error-page/error-page.ts
+++ b/packages/web/titanium/error-page/error-page.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, TemplateResult } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
 
 /**
@@ -13,7 +13,7 @@ export class TitaniumErrorPage extends LitElement {
   /**
    * Reason text for the error
    */
-  @property({ type: String }) accessor message: string = 'We were unable to find the page you are looking for...';
+  @property() accessor message: string | TemplateResult<1> = 'We were unable to find the page you are looking for...';
 
   static styles = css`
     :host {


### PR DESCRIPTION
## Summary
- Update `heading` and `message` properties on `<leavitt-error-page>` and `message` on `<titanium-error-page>` to accept `string | TemplateResult<1>`, allowing callers to pass rich HTML content (links, inline icons, formatted text).
- Remove `{ type: String }` from the `@property` decorators since the value can now be a `TemplateResult` and won't be set via attribute.
- Add demo examples in both leavittbook storybook demos showcasing `TemplateResult` usage with styled anchor tags.

## Test plan
- [ ] Verify existing string-based usage still renders correctly in both error page demos
- [ ] Verify the new TemplateResult demo renders links and styled text properly
- [ ] Confirm no lit-plugin or TypeScript errors in the modified files


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public API for `leavitt-error-page`/`titanium-error-page` props to accept `TemplateResult`, which could impact consumers relying on attribute-based string coercion and requires verifying mixed string/template rendering paths.
> 
> **Overview**
> **Error page components now accept rich templated content.** `leavitt-error-page` updates `heading` and `message`, and `titanium-error-page` updates `message`, to support `string | TemplateResult` values (and removes `{ type: String }` coercion in the decorators).
> 
> Leavittbook demos are extended with new examples passing `html` template messages (including styled links via `titanium` `p`/`a` styles) to showcase the new capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c28ca9f31159cf768555779e75c79966a6132d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->