### PR TITLE
fix: shrink drawer footer gap a bit to prevent line-break when 3-items

### DIFF
--- a/packages/web/titanium/drawer/drawer.ts
+++ b/packages/web/titanium/drawer/drawer.ts
@@ -269,7 +269,7 @@ export class TitaniumDrawer extends LitElement {
       display: flex;
       flex-direction: row;
       padding: 8px 24px;
-      gap: 24px;
+      gap: 20px;
     }
 
     footer ::slotted(a) {


### PR DESCRIPTION
Just reduces the gap a bit so sites with Email history don't line-break
<img width="322" height="59" alt="Screenshot 2026-06-01 at 3 13 57 PM" src="https://github.com/user-attachments/assets/ab1e7e5b-fcc4-4e49-b5b4-19d58f104ab2" />
<img width="317" height="68" alt="Screenshot 2026-06-01 at 3 14 27 PM" src="https://github.com/user-attachments/assets/bcdefc48-b6d6-4bd7-aecf-a4201cb4e15f" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS spacing tweak in drawer footer styling with no logic or API changes.
> 
> **Overview**
> **Tightens horizontal spacing** in the `titanium-drawer` footer row by changing the flex `gap` from **24px** to **20px** when `has-footer` is set.
> 
> This keeps three footer links (e.g. layouts that include Email history) on one line instead of wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc70baad0386e97465c88f114ee1a79787e95db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->