### PR TITLE
fix: broaden abort error check to suppress native browser abort messages

### DIFF
--- a/packages/web/leavitt/person-company-select/person-company-select.ts
+++ b/packages/web/leavitt/person-company-select/person-company-select.ts
@@ -108,7 +108,7 @@ export class LeavittPersonCompanySelect extends TitaniumSingleSelectBase<Partial
       results?.entities.forEach((p) => (p.type = 'Person'));
       return results;
     } catch (error) {
-      if (!error?.message?.includes('Abort error')) {
+      if (!error?.message?.toLowerCase().includes('abort')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }
@@ -134,7 +134,7 @@ export class LeavittPersonCompanySelect extends TitaniumSingleSelectBase<Partial
       results?.entities.forEach((p) => (p.type = 'Company'));
       return results;
     } catch (error) {
-      if (!error?.message?.includes('Abort error')) {
+      if (!error?.message?.toLowerCase().includes('abort')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }

--- a/packages/web/leavitt/person-company-select/person-company-select.ts
+++ b/packages/web/leavitt/person-company-select/person-company-select.ts
@@ -108,7 +108,7 @@ export class LeavittPersonCompanySelect extends TitaniumSingleSelectBase<Partial
       results?.entities.forEach((p) => (p.type = 'Person'));
       return results;
     } catch (error) {
-      if (!error?.message?.toLowerCase().includes('abort')) {
+      if (error?.name !== 'AbortError' && !error?.message?.includes('Abort error')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }
@@ -134,7 +134,7 @@ export class LeavittPersonCompanySelect extends TitaniumSingleSelectBase<Partial
       results?.entities.forEach((p) => (p.type = 'Company'));
       return results;
     } catch (error) {
-      if (!error?.message?.toLowerCase().includes('abort')) {
+      if (error?.name !== 'AbortError' && !error?.message?.includes('Abort error')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }

--- a/packages/web/leavitt/person-group-select/person-group-select.ts
+++ b/packages/web/leavitt/person-group-select/person-group-select.ts
@@ -107,7 +107,7 @@ export class LeavittPersonGroupSelect extends TitaniumSingleSelectBase<Partial<P
       results?.entities.forEach((p) => (p.type = 'Person'));
       return results;
     } catch (error) {
-      if (!error?.message?.toLowerCase().includes('abort')) {
+      if (error?.name !== 'AbortError' && !error?.message?.includes('Abort error')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }
@@ -138,7 +138,7 @@ export class LeavittPersonGroupSelect extends TitaniumSingleSelectBase<Partial<P
       results?.entities.forEach((p) => (p.type = 'PeopleGroup'));
       return results;
     } catch (error) {
-      if (!error?.message?.toLowerCase().includes('abort')) {
+      if (error?.name !== 'AbortError' && !error?.message?.includes('Abort error')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }

--- a/packages/web/leavitt/person-group-select/person-group-select.ts
+++ b/packages/web/leavitt/person-group-select/person-group-select.ts
@@ -107,7 +107,7 @@ export class LeavittPersonGroupSelect extends TitaniumSingleSelectBase<Partial<P
       results?.entities.forEach((p) => (p.type = 'Person'));
       return results;
     } catch (error) {
-      if (!error?.message?.includes('Abort error')) {
+      if (!error?.message?.toLowerCase().includes('abort')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }
@@ -138,7 +138,7 @@ export class LeavittPersonGroupSelect extends TitaniumSingleSelectBase<Partial<P
       results?.entities.forEach((p) => (p.type = 'PeopleGroup'));
       return results;
     } catch (error) {
-      if (!error?.message?.includes('Abort error')) {
+      if (!error?.message?.toLowerCase().includes('abort')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }

--- a/packages/web/leavitt/person-select/person-select.ts
+++ b/packages/web/leavitt/person-select/person-select.ts
@@ -146,7 +146,7 @@ export class LeavittPersonSelect extends TitaniumSingleSelectBase<Partial<Person
         const result = await get;
         this.showSuggestions(result?.entities ?? [], result?.odataCount ?? 0);
       } catch (error) {
-        if (!error?.message?.toLowerCase().includes('abort')) {
+        if (error?.name !== 'AbortError' && !error?.message?.includes('Abort error')) {
           this.dispatchEvent(new ShowSnackbarEvent(error));
         }
       }

--- a/packages/web/leavitt/person-select/person-select.ts
+++ b/packages/web/leavitt/person-select/person-select.ts
@@ -146,7 +146,7 @@ export class LeavittPersonSelect extends TitaniumSingleSelectBase<Partial<Person
         const result = await get;
         this.showSuggestions(result?.entities ?? [], result?.odataCount ?? 0);
       } catch (error) {
-        if (!error?.message?.includes('Abort error')) {
+        if (!error?.message?.toLowerCase().includes('abort')) {
           this.dispatchEvent(new ShowSnackbarEvent(error));
         }
       }

--- a/packages/web/titanium/address-input/google-address-input.ts
+++ b/packages/web/titanium/address-input/google-address-input.ts
@@ -131,7 +131,7 @@ export class GoogleAddressInput extends TitaniumSingleSelectBase<AddressInputAdd
       this.showSuggestions(results, results.length);
       return;
     } catch (error) {
-      if (!error?.message?.toLowerCase().includes('abort')) {
+      if (error?.name !== 'AbortError' && !error?.message?.includes('Abort error')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }

--- a/packages/web/titanium/address-input/google-address-input.ts
+++ b/packages/web/titanium/address-input/google-address-input.ts
@@ -131,7 +131,7 @@ export class GoogleAddressInput extends TitaniumSingleSelectBase<AddressInputAdd
       this.showSuggestions(results, results.length);
       return;
     } catch (error) {
-      if (!error?.message?.includes('Abort error')) {
+      if (!error?.message?.toLowerCase().includes('abort')) {
         this.dispatchEvent(new ShowSnackbarEvent(error));
       }
     }


### PR DESCRIPTION
## Summary
- Broadens the abort error suppression check in all select components from `includes('Abort error')` to `toLowerCase().includes('abort')`, catching both the ApiService-rewritten message and the raw browser `DOMException` message (`"The user aborted a request."`) that was leaking through as a user-facing toast.
- Affected components: `person-group-select`, `person-select`, `person-company-select`, `google-address-input`

## Test plan
- [ ] Use a `leavitt-person-group-select` and type quickly to trigger request cancellation — verify no abort error toast appears
- [ ] Repeat for `leavitt-person-select`, `leavitt-person-company-select`, and `google-address-input`
- [ ] Verify that real (non-abort) API errors still display a snackbar as expected

Made with [Cursor](https://cursor.com)