### PR TITLE
fix(styles): omit bottom border on last visible data-row

### DIFF
--- a/packages/web/titanium/styles/data-row.ts
+++ b/packages/web/titanium/styles/data-row.ts
@@ -18,7 +18,7 @@ export const dataRow = [
       border-bottom: 1px solid var(--md-sys-color-outline-variant);
     }
 
-    data-row:last-of-type {
+    data-row:not([hidden]):not(:has(~ data-row:not([hidden]))) {
       border: none;
     }
 


### PR DESCRIPTION
## Summary

- **Fixes `dataRow` bottom border** when the next sibling row is hidden — replaces `:last-of-type` with a selector that only considers visible `data-row` elements
- **Prevents stray dividers** on the last visible row in overview cards (e.g. when a conditional Ricochet row is `hidden`)

## Pages changed

_(None — shared style change in `@leavittsoftware/web`; consumers pick up the fix on the next package release.)_
